### PR TITLE
Makefile: make rustc-nightly directory a direct depenency of test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ output/rust/%.o: $(RUST_TESTS_DIR)%.rs $(RUSTCSRC) $(BIN)
 	touch $@
 
 .PHONY: test test_rustos
-test: output/libcore.hir output/liballoc.hir output/libcollections.hir output/libstd.hir $(BIN)
+test: $(RUSTCSRC) output/libcore.hir output/liballoc.hir output/libcollections.hir output/libstd.hir $(BIN)
 
 test_rustos: $(addprefix output/rust_os/,libkernel.rlib)
 


### PR DESCRIPTION
Make test will now download rustc on a clean clone