### PR TITLE
Fix build on gcc 6.2

### DIFF
--- a/src/hir/serialise_lowlevel.hpp
+++ b/src/hir/serialise_lowlevel.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/iostreams/filtering_stream.hpp>
 #include <fstream>
+#include <vector>
 
 namespace HIR {
 namespace serialise {

--- a/src/mir/from_hir_match.cpp
+++ b/src/mir/from_hir_match.cpp
@@ -8,6 +8,7 @@
 #include "from_hir.hpp"
 #include <hir_typeck/common.hpp>   // monomorphise_type
 #include <algorithm>
+#include <numeric>
 
 void MIR_LowerHIR_Match( MirBuilder& builder, MirConverter& conv, ::HIR::ExprNode_Match& node, ::MIR::LValue match_val );
 


### PR DESCRIPTION
It gave me a build error when I tried to compile it on gcc 6.2.

Also, if you are interested, this is a list of compilation warnings I've encountered with the compiler version: http://pastebin.com/W0rXwnWF

Just mentioned those as I could remember mrustc didn't do any warnings back when I was on the older gcc version.