### PR TITLE
Fix build

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -9,6 +9,7 @@
 #include "mangling.hpp"
 #include <fstream>
 #include <algorithm>
+#include <cmath>
 #include <hir/hir.hpp>
 #include <mir/mir.hpp>
 #include <hir_typeck/static.hpp>


### PR DESCRIPTION
Build errored for me with:

```
src/trans/codegen_c.cpp:1129:37: error: ‘isnan’ is not a member of ‘std’
                                 if( ::std::isnan(c) ) {
src/trans/codegen_c.cpp:1132:42: error: ‘isinf’ is not a member of ‘std’
                                 else if( ::std::isinf(c) ) {
```

now it does not anymore.