### PR TITLE
Remove CMake update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ addons:
  apt:
   sources:
     - ubuntu-toolchain-r-test
-    - george-edison55-precise-backports
   packages:
     - g++-6
     - zlib1g-dev
-    - cmake cmake-data
 
 install:
  # Build mrustc


### PR DESCRIPTION
Travis CI has moved from Precise to Trusty.
Since Trusty has CMake 3.2.2 by default, manual update isn't needed anymore.