### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/src/hir/item_path.hpp
+++ b/src/hir/item_path.hpp
@@ -35,6 +35,15 @@ public:
     ItemPath(const ::HIR::SimplePath& path):
         trait(&path)
     {}
+    ItemPath(const ::HIR::ItemPath& other) :
+        parent(other.parent),
+        ty(other.ty),
+        trait(other.trait),
+        trait_params(other.trait_params),
+        name(other.name),
+        crate_name(other.crate_name)
+    {}
+
 
     const ::HIR::SimplePath* trait_path() const { return trait; }
     const ::HIR::PathParams* trait_args() const { return trait_params; }

--- a/src/hir_conv/markings.cpp
+++ b/src/hir_conv/markings.cpp
@@ -57,7 +57,7 @@ public:
             for(size_t i = 0; i < str.m_params.m_types.size(); i++)
             {
                 const auto& param = str.m_params.m_types[i];
-                auto ty = ::HIR::TypeRef(param.m_name, i);
+                ty = ::HIR::TypeRef(param.m_name, i);
                 if( !param.m_is_sized )
                 {
                     if( visit_ty_with(last_field_ty, [&](const auto& t){ return t == ty; }) )

--- a/src/hir_typeck/outer.cpp
+++ b/src/hir_typeck/outer.cpp
@@ -81,7 +81,7 @@ namespace {
         StaticTraitResolve  m_resolve;
 
         const ::HIR::Trait* m_current_trait = nullptr;
-        const ::HIR::ItemPath* m_current_trait_path = nullptr;
+        ::std::unique_ptr<const ::HIR::ItemPath> m_current_trait_path;
 
 
         ::HIR::ItemPath* m_fcn_path = nullptr;
@@ -591,7 +591,7 @@ namespace {
         void visit_trait(::HIR::ItemPath p, ::HIR::Trait& item) override
         {
             m_current_trait = &item;
-            m_current_trait_path = &p;
+            m_current_trait_path = ::std::make_unique<const ::HIR::ItemPath>(p);
 
             auto _ = m_resolve.set_impl_generics(item.m_params);
             ::HIR::TypeRef tr { "Self", 0xFFFF };

--- a/src/parse/root.cpp
+++ b/src/parse/root.cpp
@@ -1853,7 +1853,7 @@ bool Parse_MacroInvocation_Opt(TokenStream& lex,  AST::MacroInvocation& out_inv)
 void Parse_Mod_Item(TokenStream& lex, AST::Module& mod, AST::MetaItems meta_items)
 {
     SET_MODULE(lex, mod);
-    lex.parse_state().parent_attrs = &meta_items;
+    lex.parse_state().parent_attrs = rc_new$(meta_items.clone());
 
     //TRACE_FUNCTION;
     Token   tok;

--- a/src/parse/tokenstream.hpp
+++ b/src/parse/tokenstream.hpp
@@ -28,7 +28,7 @@ struct ParseState
     bool no_expand_macros = false;
 
     ::AST::Module*  module = nullptr;
-    ::AST::MetaItems*   parent_attrs = nullptr;
+    ::std::shared_ptr<::AST::MetaItems> parent_attrs;
 
     ::AST::Module& get_current_mod() {
         assert(this->module);
@@ -99,7 +99,7 @@ public:
 };
 
 #define SET_MODULE(lex, mod)    SavedParseState _sps(lex, lex.parse_state()); lex.parse_state().module = &(mod)
-#define SET_ATTRS(lex, attrs)    SavedParseState _sps(lex, lex.parse_state()); lex.parse_state().parent_attrs = &(attrs)
+#define SET_ATTRS(lex, attrs)    SavedParseState _sps(lex, lex.parse_state()); lex.parse_state().parent_attrs = rc_new$(attrs.clone())
 #define SET_PARSE_FLAG(lex, flag)    SavedParseState _sps(lex, lex.parse_state()); lex.parse_state().flag = true
 #define CLEAR_PARSE_FLAG(lex, flag)    SavedParseState _sps(lex, lex.parse_state()); lex.parse_state().flag = false
 #define CHECK_PARSE_FLAG(lex, flag) (lex.parse_state().flag == true)

--- a/src/resolve/absolute.cpp
+++ b/src/resolve/absolute.cpp
@@ -549,7 +549,7 @@ void Resolve_Absolute_PathNodes(/*const*/ Context& context, const Span& sp, ::st
     }
 }
 
-void Resolve_Absolute_Path_BindUFCS(Context& context, const Span& sp, Context::LookupMode& mode, ::AST::Path& path)
+void Resolve_Absolute_Path_BindUFCS(Context& context, const Span& sp, Context::LookupMode mode, ::AST::Path& path)
 {
     while( path.m_class.as_UFCS().nodes.size() > 1 )
     {
@@ -986,6 +986,7 @@ namespace {
                     )
                 }
             }
+            break;
         case Context::LookupMode::PatternValue:
             {
                 auto v = hmod->m_value_items.find(name);

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -124,7 +124,7 @@ namespace {
         ::std::string   m_outfile_path_c;
 
         ::std::ofstream m_of;
-        const ::MIR::TypeResolve* m_mir_res;
+        ::std::unique_ptr<const ::MIR::TypeResolve> m_mir_res;
 
         Compiler    m_compiler = Compiler::Gcc;
         struct {
@@ -619,8 +619,7 @@ namespace {
             ::std::vector< ::std::pair<::HIR::Pattern,::HIR::TypeRef> > args;
             args.push_back( ::std::make_pair( ::HIR::Pattern {}, mv$(inner_ptr) ) );
 
-            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, args, *(::MIR::Function*)nullptr };
-            m_mir_res = &mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, args, *(::MIR::Function*)nullptr });
             m_of << "static void " << Trans_Mangle(drop_glue_path) << "(struct s_" << Trans_Mangle(p) << "* rv) {\n";
 
             // Obtain inner pointer
@@ -632,7 +631,7 @@ namespace {
             m_of << "\t" << Trans_Mangle(box_free) << "(arg0);\n";
 
             m_of << "}\n";
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
 
         void emit_type_id(const ::HIR::TypeRef& ty) override
@@ -723,8 +722,7 @@ namespace {
         }
         void emit_type(const ::HIR::TypeRef& ty) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "type " << ty;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "type " << ty;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(ty);
             TU_IFLET( ::HIR::TypeRef::Data, ty.m_data, Tuple, te,
@@ -743,8 +741,7 @@ namespace {
                 auto drop_glue_path = ::HIR::Path(ty.clone(), "#drop_glue");
                 auto args = ::std::vector< ::std::pair<::HIR::Pattern,::HIR::TypeRef> >();
                 auto ty_ptr = ::HIR::TypeRef::new_pointer(::HIR::BorrowType::Owned, ty.clone());
-                ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), ty_ptr, args, *(::MIR::Function*)nullptr };
-                m_mir_res = &mir_res;
+                m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), ty_ptr, args, *(::MIR::Function*)nullptr });
                 m_of << "static void " << Trans_Mangle(drop_glue_path) << "("; emit_ctype(ty); m_of << "* rv) {";
                 auto self = ::MIR::LValue::make_Deref({ box$(::MIR::LValue::make_Return({})) });
                 auto fld_lv = ::MIR::LValue::make_Field({ box$(self), 0 });
@@ -769,13 +766,12 @@ namespace {
             else {
             }
 
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
 
         void emit_struct(const Span& sp, const ::HIR::GenericPath& p, const ::HIR::Struct& item) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "struct " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "struct " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
             ::HIR::TypeRef  tmp;
@@ -893,8 +889,7 @@ namespace {
                 return ;
             }
 
-            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, args, *(::MIR::Function*)nullptr };
-            m_mir_res = &mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, args, *(::MIR::Function*)nullptr });
             m_of << "static void " << Trans_Mangle(drop_glue_path) << "("; emit_ctype(struct_ty_ptr, FMT_CB(ss, ss << "rv";)); m_of << ") {\n";
 
             // If this type has an impl of Drop, call that impl
@@ -927,12 +922,11 @@ namespace {
                 )
             )
             m_of << "}\n";
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
         void emit_union(const Span& sp, const ::HIR::GenericPath& p, const ::HIR::Union& item) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "union " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "union " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
 
@@ -959,8 +953,7 @@ namespace {
             auto drop_glue_path = ::HIR::Path(item_ty.clone(), "#drop_glue");
             auto item_ptr_ty = ::HIR::TypeRef::new_borrow(::HIR::BorrowType::Owned, item_ty.clone());
             auto drop_impl_path = (item.m_markings.has_drop_impl ? ::HIR::Path(item_ty.clone(), m_resolve.m_lang_Drop, "drop") : ::HIR::Path(::HIR::SimplePath()));
-            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), item_ptr_ty, {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), item_ptr_ty, {}, *(::MIR::Function*)nullptr });
 
             if( item.m_markings.has_drop_impl )
             {
@@ -1010,8 +1003,7 @@ namespace {
 
         void emit_enum(const Span& sp, const ::HIR::GenericPath& p, const ::HIR::Enum& item) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "enum " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "enum " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
             ::HIR::TypeRef  tmp;
@@ -1134,8 +1126,7 @@ namespace {
             auto drop_glue_path = ::HIR::Path(struct_ty.clone(), "#drop_glue");
             auto struct_ty_ptr = ::HIR::TypeRef::new_borrow(::HIR::BorrowType::Owned, struct_ty.clone());
             auto drop_impl_path = (item.m_markings.has_drop_impl ? ::HIR::Path(struct_ty.clone(), m_resolve.m_lang_Drop, "drop") : ::HIR::Path(::HIR::SimplePath()));
-            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, {}, *(::MIR::Function*)nullptr });
 
             if( item.m_markings.has_drop_impl )
             {
@@ -1208,7 +1199,7 @@ namespace {
                 m_of << "\t}\n";
             }
             m_of << "}\n";
-            m_mir_res = nullptr;
+            m_mir_res.reset();
 
             if( nonzero_path.size() )
             {
@@ -1320,8 +1311,7 @@ namespace {
 
         void emit_static_ext(const ::HIR::Path& p, const ::HIR::Static& item, const Trans_Params& params) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "extern static " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "extern static " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
             TRACE_FUNCTION_F(p);
 
             if( item.m_linkage.name != "" && m_compiler != Compiler::Gcc )
@@ -1351,12 +1341,11 @@ namespace {
             m_of << "\t// static " << p << " : " << type;
             m_of << "\n";
 
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
         void emit_static_proto(const ::HIR::Path& p, const ::HIR::Static& item, const Trans_Params& params) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "static " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "static " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
             auto type = params.monomorph(m_resolve, item.m_type);
@@ -1365,12 +1354,11 @@ namespace {
             m_of << "\t// static " << p << " : " << type;
             m_of << "\n";
 
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
         void emit_static_local(const ::HIR::Path& p, const ::HIR::Static& item, const Trans_Params& params) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "static " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "static " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
 
@@ -1677,8 +1665,7 @@ namespace {
 
         void emit_vtable(const ::HIR::Path& p, const ::HIR::Trait& trait) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "vtable " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "vtable " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
             const auto& trait_path = p.m_data.as_UfcsKnown().trait;
@@ -1774,13 +1761,12 @@ namespace {
             m_of << "\n";
             m_of << "\t};\n";
 
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
 
         void emit_function_ext(const ::HIR::Path& p, const ::HIR::Function& item, const Trans_Params& params) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "extern fn " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "extern fn " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
             TRACE_FUNCTION_F(p);
 
             if (item.m_linkage.name != "" && m_compiler != Compiler::Gcc)
@@ -1808,12 +1794,11 @@ namespace {
             }
             m_of << ";\n";
 
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
         void emit_function_proto(const ::HIR::Path& p, const ::HIR::Function& item, const Trans_Params& params, bool is_extern_def) override
         {
-            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "/*proto*/ fn " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr };
-            m_mir_res = &top_mir_res;
+            m_mir_res = box$(::MIR::TypeResolve{ sp, m_resolve, FMT_CB(ss, ss << "/*proto*/ fn " << p;), ::HIR::TypeRef(), {}, *(::MIR::Function*)nullptr });
 
             TRACE_FUNCTION_F(p);
             m_of << "// PROTO extern \"" << item.m_abi << "\" " << p << "\n";
@@ -1828,7 +1813,7 @@ namespace {
             emit_function_header(p, item, params);
             m_of << ";\n";
 
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
         void emit_function_code(const ::HIR::Path& p, const ::HIR::Function& item, const Trans_Params& params, bool is_extern_def, const ::MIR::FunctionPointer& code) override
         {
@@ -1841,8 +1826,8 @@ namespace {
             ::HIR::TypeRef  ret_type_tmp;
             const auto& ret_type = monomorphise_fcn_return(ret_type_tmp, item, params);
 
-            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << p;), ret_type, arg_types, *code };
-            m_mir_res = &mir_res;
+            ::MIR::TypeResolve  mir_res{ sp, m_resolve, FMT_CB(ss, ss << p;), ret_type, arg_types, *code };
+            m_mir_res = ::std::make_unique<::MIR::TypeResolve>(mir_res);
 
             m_of << "// " << p << "\n";
             if( is_extern_def ) {
@@ -2040,7 +2025,7 @@ namespace {
             }
             m_of << "}\n";
             m_of.flush();
-            m_mir_res = nullptr;
+            m_mir_res.reset();
         }
 
         void emit_fcn_node(::MIR::TypeResolve& mir_res, const Node& node, unsigned indent_level)
@@ -3739,7 +3724,7 @@ namespace {
                 emit_lvalue(e.ret_val); m_of << " = sin" << (name.back()=='2'?"f":"") << "("; emit_param(e.args.at(0)); m_of << ")";
             }
             else if( name == "fmaf32" || name == "fmaf64" ) {
-                emit_lvalue(e.ret_val); m_of << " = fma" << (name.back()=='2'?"f":"") << "("; emit_param(e.args.at(0)); m_of << ", "; emit_param(e.args.at(1)); m_of << ", "; emit_param(e.args.at(1)); m_of << ")";
+                emit_lvalue(e.ret_val); m_of << " = fma" << (name.back()=='2'?"f":"") << "("; emit_param(e.args.at(0)); m_of << ", "; emit_param(e.args.at(1)); m_of << ")";
             }
             // --- Volatile Load/Store
             else if( name == "volatile_load" ) {


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

- [V561 ](https://www.viva64.com/en/w/v561/)It's probably better to assign value to 'ty' variable than to declare it anew. Previous declaration: markings.cpp, line 56. markings.cpp 60
- [V506](https://www.viva64.com/en/w/v506/) Pointer to local variable 'p' is stored outside the scope of this variable. Such a pointer will become invalid. resolve_ufcs.cpp 82
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'p' is stored outside the scope of this variable. Such a pointer will become invalid. resolve_ufcs.cpp 103
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'root_mod_path' is stored outside the scope of this variable. Such a pointer will become invalid. closures.cpp 1014
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'p' is stored outside the scope of this variable. Such a pointer will become invalid. outer.cpp 594
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'item_attrs' is stored outside the scope of this variable. Such a pointer will become invalid. root.cpp 551
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'item_attrs' is stored outside the scope of this variable. Such a pointer will become invalid. root.cpp 586
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'item_attrs' is stored outside the scope of this variable. Such a pointer will become invalid. root.cpp 666
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'item_attrs' is stored outside the scope of this variable. Such a pointer will become invalid. root.cpp 827
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'item_attrs' is stored outside the scope of this variable. Such a pointer will become invalid. root.cpp 928
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'meta_items' is stored outside the scope of this variable. Such a pointer will become invalid. root.cpp 1232
- [V796 ](https://www.viva64.com/en/w/v796/)It is possible that 'break' statement is missing in switch statement. absolute.cpp 988
- [V506 ](https://www.viva64.com/en/w/v506/) Pointer to local variable 'mir_res' is stored outside the scope of this variable. Such a pointer will become invalid. codegen_c.cpp 963
- [V669 ](https://www.viva64.com/en/w/v669/)The 'mode' argument is a non-constant reference. The analyzer is unable to determine the position at which this argument is being modified. It is possible that the function contains an error. absolute.cpp 552
- [V760 ](https://www.viva64.com/en/w/v760/)Two identical blocks of text were found. The second block begins from line 3727. codegen_c.cpp 3727

There are actually way more warnings were found but you can inspect them on your own using PVS-Studio analyzer.