### PR TITLE
Remove dynamic_cast in FMT

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -15,7 +15,7 @@
 #define __attribute__(x)    /* no-op */
 #endif
 
-#define FMT(ss)    (dynamic_cast< ::std::stringstream&>(::std::stringstream() << ss).str())
+#define FMT(ss)    ((::std::stringstream() << ss).str())
 // XXX: Evil hack - Define 'mv$' to be ::std::move
 #define mv$(x)    ::std::move(x)
 #define box$(...) ::make_unique_ptr(::std::move(__VA_ARGS__))


### PR DESCRIPTION
This fixes error on macOS like the following.

```
src/main.cpp:308:34: error: dynamic_cast from rvalue to reference type '::std::stringstream &' (aka 'basic_stringstream<char> &')
                params.outfile = FMT(params.output_dir << "lib" << crate.m_crate_name << ".hir");
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/common.hpp:18:21: note: expanded from macro 'FMT'
#define FMT(ss)    (dynamic_cast< ::std::stringstream&>(::std::stringstream() << ss).str())
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I'm not very good at C++, so feel free to point out my mistake.