### PR TITLE
Fix FMT

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -15,7 +15,7 @@
 #define __attribute__(x)    /* no-op */
 #endif
 
-#define FMT(ss)    (dynamic_cast< ::std::stringstream&>(::std::stringstream() << ss).str())
+#define FMT(ss)    (static_cast<::std::ostringstream&&>(::std::ostringstream() << ss).str())
 // XXX: Evil hack - Define 'mv$' to be ::std::move
 #define mv$(x)    ::std::move(x)
 #define box$(...) ::make_unique_ptr(::std::move(__VA_ARGS__))


### PR DESCRIPTION
- Use `ostringstream`, since `operator>>` is not needed.
- Use `static_cast`, since no runtime check is needed.
- Cast to `::std::ostringstream&&` instead of `::std::ostringstream&`, this should fix error on macOS like the following.

```
src/main.cpp:308:34: error: dynamic_cast from rvalue to reference type '::std::stringstream &' (aka 'basic_stringstream<char> &')
                params.outfile = FMT(params.output_dir << "lib" << crate.m_crate_name << ".hir");
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/common.hpp:18:21: note: expanded from macro 'FMT'
#define FMT(ss)    (dynamic_cast< ::std::stringstream&>(::std::stringstream() << ss).str())
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```