### PR TITLE
Fix enums with `repr(u64)`

### DIFF
--- a/src/hir/from_ast.cpp
+++ b/src/hir/from_ast.cpp
@@ -927,7 +927,7 @@ namespace {
                 repr = ::HIR::Enum::Repr::U32;
             }
             else if( repr_str == "u64") {
-                repr = ::HIR::Enum::Repr::U32;
+                repr = ::HIR::Enum::Repr::U64;
             }
             else if( repr_str == "usize") {
                 repr = ::HIR::Enum::Repr::Usize;

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1203,7 +1203,7 @@ namespace {
                     m_of << "\tuint32_t TAG;\n";
                     break;
                 case ::HIR::Enum::Repr::U64:
-                    m_of << "\tuint32_t TAG;\n";
+                    m_of << "\tuint64_t TAG;\n";
                     break;
                 }
                 m_of << "};\n";


### PR DESCRIPTION
Use `uint64_t` for enums with `repr(u64)`.