### PR TITLE
main - fix incorrect type deduction with some gcc versions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -773,7 +773,7 @@ ProgramParams::ProgramParams(int argc, char *argv[])
                     exit(1);
                 }
                 const char* desc = argv[++i];
-                auto* pos = ::std::strchr(desc, '=');
+                const char* pos = ::std::strchr(desc, '=');
                 if( pos == nullptr ) {
                     ::std::cerr << "--extern takes an argument of the format name=path" << ::std::endl;
                     exit(1);


### PR DESCRIPTION
GCC 6.4 on Alpine incorrectly deduces the type returned from

    ::std::strchr(const char *, char)

as 'char *', instead of 'const char *', which causes the wrong constructor
to be used.

Closes #32.