### PR TITLE
Merge "common_layout" branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@
 /bnf/rust.output
 /bnf/test.bin
 /vsproject/output
+/vsproject/output_mmir
 /vsproject/standalone_miri/x64

--- a/src/hir/hir.hpp
+++ b/src/hir/hir.hpp
@@ -227,6 +227,7 @@ public:
     struct ValueVariant {
         ::std::string   name;
         ::HIR::ExprPtr  expr;
+        // TODO: Signed.
         uint64_t val;
     };
     TAGGED_UNION(Class, Data,

--- a/src/hir/type.cpp
+++ b/src/hir/type.cpp
@@ -105,8 +105,11 @@ void ::HIR::TypeRef::fmt(::std::ostream& os) const
         os << "*/";
         ),
     (TraitObject,
-        os << "(";
-        os << e.m_trait;
+        os << "dyn (";
+        if( e.m_trait.m_path != ::HIR::GenericPath() )
+        {
+            os << e.m_trait;
+        }
         for(const auto& tr : e.m_markers)
             os << "+" << tr;
         if( e.m_lifetime.name != "" )

--- a/src/include/tagged_union.hpp
+++ b/src/include/tagged_union.hpp
@@ -110,7 +110,7 @@
 #define TU_IFLET(CLASS, VAR, TAG, NAME, ...) if(VAR.tag() == CLASS::TAG_##TAG) { auto& NAME = VAR.as_##TAG(); (void)&NAME; __VA_ARGS__ }
 
 // Evil hack: two for loops, the inner stops the outer after it's done.
-#define TU_ARM(VAR, TAG, NAME)  case ::std::remove_reference<decltype(VAR)>::type::TAG_##TAG: for(bool tu_lc = true; tu_lc;) for(auto& NAME = VAR.as_##TAG(); tu_lc; tu_lc=false)
+#define TU_ARM(VAR, TAG, NAME)  case ::std::remove_reference<decltype(VAR)>::type::TAG_##TAG: for(bool tu_lc = true; tu_lc; tu_lc=false) for(auto& NAME = VAR.as_##TAG(); tu_lc; tu_lc=false)
 
 //#define TU_TEST(VAL, ...)    (VAL.is_##TAG() && VAL.as_##TAG() TEST)
 #define TU_TEST1(VAL, TAG1, TEST)    (VAL.is_##TAG1() && VAL.as_##TAG1() TEST)

--- a/src/include/tagged_union.hpp
+++ b/src/include/tagged_union.hpp
@@ -110,7 +110,7 @@
 #define TU_IFLET(CLASS, VAR, TAG, NAME, ...) if(VAR.tag() == CLASS::TAG_##TAG) { auto& NAME = VAR.as_##TAG(); (void)&NAME; __VA_ARGS__ }
 
 // Evil hack: two for loops, the inner stops the outer after it's done.
-#define TU_ARM(VAR, TAG, NAME)  case ::std::remove_reference<decltype(VAR)>::type::TAG_##TAG: for(bool tu_lc = true; tu_lc; tu_lc=false) for(auto& NAME = VAR.as_##TAG(); tu_lc; tu_lc=false)
+#define TU_ARM(VAR, TAG, NAME)  case ::std::remove_reference<decltype(VAR)>::type::TAG_##TAG: for(bool tu_lc = true; tu_lc; tu_lc=false) for(auto& NAME = VAR.as_##TAG(); (void)NAME, tu_lc; tu_lc=false)
 
 //#define TU_TEST(VAL, ...)    (VAL.is_##TAG() && VAL.as_##TAG() TEST)
 #define TU_TEST1(VAL, TAG1, TEST)    (VAL.is_##TAG1() && VAL.as_##TAG1() TEST)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,7 @@ struct ProgramParams
         bool full_validate_early = false;
     } debug;
     struct {
+        ::std::string   codegen_type;
         ::std::string   emit_build_command;
     } codegen;
 
@@ -603,6 +604,7 @@ int main(int argc, char *argv[])
         // - MIR Exportable (public generic, #[inline], or used by a either of those)
         // - Require codegen (public or used by an exported function)
         TransOptions    trans_opt;
+        trans_opt.mode = params.codegen.codegen_type == "" ? "c" : params.codegen.codegen_type;
         trans_opt.build_command_file = params.codegen.emit_build_command;
         trans_opt.opt_level = params.opt_level;
         for(const char* libdir : params.lib_search_dirs ) {
@@ -781,6 +783,10 @@ ProgramParams::ProgramParams(int argc, char *argv[])
                 if( optname == "emit-build-command" ) {
                     get_optval();
                     this->codegen.emit_build_command = optval;
+                }
+                else if( optname == "codegen-type" ) {
+                    get_optval();
+                    this->codegen.codegen_type = optval;
                 }
                 else if( optname == "emit-depfile" ) {
                     get_optval();

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -13,9 +13,11 @@ namespace MIR {
         (Int,
             os << (e.v < 0 ? "-" : "+");
             os << (e.v < 0 ? -e.v : e.v);
+            os << " " << e.t;
             ),
         (Uint,
             os << e.v;
+            os << " " << e.t;
             ),
         (Float,
             os << e.v;

--- a/src/trans/codegen.cpp
+++ b/src/trans/codegen.cpp
@@ -18,7 +18,16 @@
 void Trans_Codegen(const ::std::string& outfile, const TransOptions& opt, const ::HIR::Crate& crate, const TransList& list, bool is_executable)
 {
     static Span sp;
-    auto codegen = Trans_Codegen_GetGeneratorC(crate, outfile);
+    ::std::unique_ptr<CodeGenerator>    codegen;
+
+    if( opt.mode == "monomir" )
+    {
+        codegen = Trans_Codegen_GetGenerator_MonoMir(crate, outfile);
+    }
+    else
+    {
+        codegen = Trans_Codegen_GetGeneratorC(crate, outfile);
+    }
 
     // 1. Emit structure/type definitions.
     // - Emit in the order they're needed.

--- a/src/trans/codegen.hpp
+++ b/src/trans/codegen.hpp
@@ -56,4 +56,5 @@ public:
 
 
 extern ::std::unique_ptr<CodeGenerator> Trans_Codegen_GetGeneratorC(const ::HIR::Crate& crate, const ::std::string& outfile);
+extern ::std::unique_ptr<CodeGenerator> Trans_Codegen_GetGenerator_MonoMir(const ::HIR::Crate& crate, const ::std::string& outfile);
 

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -877,15 +877,15 @@ namespace {
                 fields.push_back(fields.size());
             }
             ::std::sort(fields.begin(), fields.end(), [&](auto a, auto b){ return repr->fields[a].offset < repr->fields[b].offset; });
-            for(const auto fld : fields)
+            for(unsigned fld : fields)
             {
                 m_of << "\t";
                 const auto& ty = repr->fields[fld].ty;
                 
-                TU_IFLET(::HIR::TypeRef::Data, ty.m_data, Slice, te,
-                    emit_ctype( *te.inner, FMT_CB(ss, ss << "_" << fld << "[0]";) );
+                if( const auto* te = ty.m_data.opt_Slice() ) {
+                    emit_ctype( *te->inner, FMT_CB(ss, ss << "_" << fld << "[0]";) );
                     has_unsized = true;
-                )
+                }
                 else TU_IFLET(::HIR::TypeRef::Data, ty.m_data, TraitObject, te,
                     m_of << "unsigned char _" << fld << "[0]";
                     has_unsized = true;
@@ -924,6 +924,7 @@ namespace {
             {
                 m_of << ";\n";
             }
+            (void)has_unsized;
 
             auto struct_ty = ::HIR::TypeRef(p.clone(), &item);
             auto drop_glue_path = ::HIR::Path(struct_ty.clone(), "#drop_glue");
@@ -1195,7 +1196,7 @@ namespace {
 
             auto p = path.clone();
             p.m_path.m_components.pop_back();
-            const auto* repr = Target_GetTypeRepr(sp, m_resolve, ::HIR::TypeRef::new_path(p.clone(), &item));
+            //const auto* repr = Target_GetTypeRepr(sp, m_resolve, ::HIR::TypeRef::new_path(p.clone(), &item));
 
             ASSERT_BUG(sp, item.m_data.is_Data(), "");
             const auto& var = item.m_data.as_Data().at(var_idx);

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1437,7 +1437,11 @@ namespace {
                 MIR_ASSERT(*m_mir_res, ty.m_data.as_Path().binding.is_Enum(), "");
                 const auto* repr = Target_GetTypeRepr(sp, m_resolve, ty);
                 const auto& enm = *ty.m_data.as_Path().binding.as_Enum();
-                if( const auto* ve = repr->variants.opt_NonZero() )
+                if( repr->variants.is_None() )
+                {
+                    m_of << "{}";
+                }
+                else if( const auto* ve = repr->variants.opt_NonZero() )
                 {
                     if( e.idx == ve->zero_variant )
                     {
@@ -2527,7 +2531,11 @@ namespace {
                         const auto& ty = mir_res.get_lvalue_type(tmp, e.dst);
                         auto* repr = Target_GetTypeRepr(sp, m_resolve, ty);
 
-                        if( const auto* re = repr->variants.opt_NonZero() )
+                        if( repr->variants.is_None() )
+                        {
+                            emit_lvalue(e.dst); m_of << ".TAG = "; emit_param(ve.val);
+                        }
+                        else if( const auto* re = repr->variants.opt_NonZero() )
                         {
                             MIR_ASSERT(*m_mir_res, ve.index < 2, "");
                             if( ve.index == re->zero_variant ) {

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1232,13 +1232,13 @@ namespace {
             switch(repr->variants.tag())
             {
             case TypeRepr::VariantMode::TAGDEAD:    throw "";
-            TU_ARM(repr->variants, Values, ve)
+            TU_ARM(repr->variants, Values, ve) {
                 m_of << " .TAG = " << ve.values[var_idx] << ",";
-                break;
-            TU_ARM(repr->variants, NonZero, ve)
-                break;
-            TU_ARM(repr->variants, None, ve)
-                break;
+                } break;
+            TU_ARM(repr->variants, NonZero, ve) {
+                } break;
+            TU_ARM(repr->variants, None, ve) {
+                } break;
             }
 
             if( e.empty() )
@@ -3566,7 +3566,7 @@ namespace {
             }
             else if( name == "write_bytes" ) {
                 // 0: Destination, 1: Value, 2: Count
-                m_of << "memset( "; emit_param(e.args.at(0));
+                m_of << "if( "; emit_param(e.args.at(2)); m_of << " > 0) memset( "; emit_param(e.args.at(0));
                     m_of << ", "; emit_param(e.args.at(1));
                     m_of << ", "; emit_param(e.args.at(2)); m_of << " * sizeof("; emit_ctype(params.m_types.at(0)); m_of << ")";
                     m_of << ")";
@@ -3685,13 +3685,13 @@ namespace {
                     TU_ARM(repr->variants, None, _e)
                         m_of << "0";
                         break;
-                    TU_ARM(repr->variants, Values, _e) {
-                        emit_param(e.args.at(0)); m_of << "->TAG";
+                    TU_ARM(repr->variants, Values, ve) {
+                        m_of << "(*"; emit_param(e.args.at(0)); m_of << ")"; emit_enum_path(repr, ve.field);
                         } break;
                     TU_ARM(repr->variants, NonZero, ve) {
-                        emit_param(e.args.at(0)); emit_enum_path(repr, ve.field); m_of << " ";
+                        m_of << "(*"; emit_param(e.args.at(0)); m_of << ")"; emit_enum_path(repr, ve.field); m_of << " ";
                         m_of << (ve.zero_variant ? "==" : "!=");
-                        m_of << "0";
+                        m_of << " 0";
                         } break;
                     }
                 }

--- a/src/trans/codegen_mmir.cpp
+++ b/src/trans/codegen_mmir.cpp
@@ -71,6 +71,13 @@ namespace
     }
     ::std::ostream& operator<<(::std::ostream& os, const Fmt<::MIR::Constant>& x)
     {
+        struct H {
+            static uint64_t double_to_u64(double v) {
+                uint64_t    rv;
+                ::std::memcpy(&rv, &v, sizeof(double));
+                return rv;
+            }
+        };
         const auto& e = x.e;
         switch(e.tag())
         {
@@ -83,7 +90,7 @@ namespace
             break;
         TU_ARM(e, Float, v) {
             // TODO: Infinity/nan/...
-            auto vi = *reinterpret_cast<const uint64_t*>(&v.v);
+            auto vi = H::double_to_u64(v.v);
             bool sign = (vi & (1ull << 63)) != 0;
             int exp = (vi >> 52) & 0x7FF;
             uint64_t frac = vi & ((1ull << 52) - 1);
@@ -222,7 +229,6 @@ namespace
 
                     m_of << "type " << ty << " {\n";
                     m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
-                    size_t  ofs = 0;
                     for(const auto& e : repr->fields)
                     {
                         m_of << "\t" << e.offset << " = " << e.ty << ";\n";
@@ -277,7 +283,6 @@ namespace
             MIR_ASSERT(*m_mir_res, repr, "No repr for struct " << ty);
             m_of << "type " << p << " {\n";
             m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
-            size_t  ofs = 0;
             for(const auto& e : repr->fields)
             {
                 m_of << "\t" << e.offset << " = " << e.ty << ";\n";
@@ -362,7 +367,6 @@ namespace
             MIR_ASSERT(*m_mir_res, repr, "No repr for union " << ty);
             m_of << "type " << p << " {\n";
             m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
-            size_t  ofs = 0;
             for(const auto& e : repr->fields)
             {
                 m_of << "\t" << e.offset << " = " << e.ty << ";\n";
@@ -407,7 +411,6 @@ namespace
             MIR_ASSERT(*m_mir_res, repr, "No repr for enum " << ty);
             m_of << "type " << p << " {\n";
             m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
-            size_t  ofs = 0;
             for(const auto& e : repr->fields)
             {
                 m_of << "\t" << e.offset << " = " << e.ty << ";\n";

--- a/src/trans/codegen_mmir.cpp
+++ b/src/trans/codegen_mmir.cpp
@@ -147,24 +147,23 @@ namespace
         {
             if( is_executable )
             {
-                m_of << "fn main(i32, *const *const i8): i32 {\n";
-                m_of << "\t0: {\n";
+                m_of << "fn ::main#(i32, *const *const i8): i32 {\n";
                 auto c_start_path = m_resolve.m_crate.get_lang_item_path_opt("mrustc-start");
                 if( c_start_path == ::HIR::SimplePath() )
                 {
-                    m_of << "\tlet m: fn();";
+                    m_of << "\tlet m: fn();\n";
                     m_of << "\t0: {\n";
-                    m_of << "\t\tASSIGN m = " << Trans_Mangle( ::HIR::GenericPath(m_resolve.m_crate.get_lang_item_path(Span(), "mrustc-main")) ) << "\n";
-                    m_of << "\t\tCALL RETURN = " << Trans_Mangle(::HIR::GenericPath(c_start_path)) << "(m, arg1, arg2) goto 1 else 1;\n";
+                    m_of << "\t\tASSIGN m = &" << ::HIR::GenericPath(m_resolve.m_crate.get_lang_item_path(Span(), "mrustc-main")) << ";\n";
+                    m_of << "\t\tCALL RETURN = " << ::HIR::GenericPath(m_resolve.m_crate.get_lang_item_path(Span(), "start")) << "(m, arg1, arg2) goto 1 else 1\n";
                 }
                 else
                 {
                     m_of << "\t0: {\n";
-                    m_of << "\t\tCALL RETURN = " << Trans_Mangle(::HIR::GenericPath(c_start_path)) << "(arg1, arg2) goto 1 else 1;\n";
+                    m_of << "\t\tCALL RETURN = " << ::HIR::GenericPath(c_start_path) << "(arg1, arg2) goto 1 else 1;\n";
                 }
                 m_of << "\t}\n";
                 m_of << "\t1: {\n";
-                m_of << "\t\tRETURN}\n";
+                m_of << "\t\tRETURN\n";
                 m_of << "\t}\n";
                 m_of << "}\n";
             }

--- a/src/trans/codegen_mmir.cpp
+++ b/src/trans/codegen_mmir.cpp
@@ -1,0 +1,766 @@
+//
+//
+//
+#include "codegen.hpp"
+#include <hir_typeck/static.hpp>
+#include <mir/helpers.hpp>
+#include "mangling.hpp"
+#include "target.hpp"
+
+#include <fstream>
+
+namespace
+{
+    template<typename T>
+    struct Fmt
+    {
+        const T&    e;
+        Fmt(const T& e):
+            e(e)
+        {
+        }
+    };
+    template<typename T> Fmt<T> fmt(const T& v) { return Fmt<T>(v); }
+
+    ::std::ostream& operator<<(::std::ostream& os, const Fmt<::MIR::LValue>& x)
+    {
+        auto fmt_lhs = [](::std::ostream& os, const ::MIR::LValue& lv) {
+            if( lv.is_Deref() ) {
+                os << "(" << fmt(lv) << ")";
+            }
+            else {
+                os << fmt(lv);
+            }
+            };
+        switch(x.e.tag())
+        {
+        case ::MIR::LValue::TAGDEAD:    throw "";
+        TU_ARM(x.e, Return, _e)
+            os << "RETURN";
+            break;
+        TU_ARM(x.e, Local, e)
+            os << "var" << e;
+            break;
+        TU_ARM(x.e, Argument, e)
+            os << "arg" << e.idx;
+            break;
+        TU_ARM(x.e, Static, e)
+            os << e;
+            break;
+        TU_ARM(x.e, Deref, e)
+            os << "*" << fmt(*e.val);
+            break;
+        TU_ARM(x.e, Field, e) {
+            fmt_lhs(os, *e.val);
+            // Avoid `0.` existing in the output
+            if( e.val->is_Field() || e.val->is_Downcast() )
+                os << " ";
+            os << "." << e.field_index;
+            } break;
+        TU_ARM(x.e, Index, e) {
+            fmt_lhs(os, *e.val);
+            os << "[" << fmt(*e.idx) << "]";
+            } break;
+        TU_ARM(x.e, Downcast, e) {
+            fmt_lhs(os, *e.val);
+            os << "@" << e.variant_index;
+            } break;
+        }
+        return os;
+    }
+    ::std::ostream& operator<<(::std::ostream& os, const Fmt<::MIR::Param>& x)
+    {
+        switch(x.e.tag())
+        {
+        case ::MIR::Param::TAGDEAD: throw "";
+        TU_ARM(x.e, LValue, e)
+            os << fmt(e);
+            break;
+        TU_ARM(x.e, Constant, e)
+            os << e;
+            break;
+        }
+        return os;
+    }
+
+    class CodeGenerator_MonoMir:
+        public CodeGenerator
+    {
+        enum class MetadataType {
+            None,
+            Slice,
+            TraitObject,
+        };
+
+        static Span sp;
+
+        const ::HIR::Crate& m_crate;
+        ::StaticTraitResolve    m_resolve;
+
+
+        ::std::string   m_outfile_path;
+        ::std::ofstream m_of;
+        const ::MIR::TypeResolve* m_mir_res;
+
+    public:
+        CodeGenerator_MonoMir(const ::HIR::Crate& crate, const ::std::string& outfile):
+            m_crate(crate),
+            m_resolve(crate),
+            m_outfile_path(outfile + ".mir"),
+            m_of(m_outfile_path)
+        {
+            for( const auto& crate : m_crate.m_ext_crates )
+            {
+                m_of << "crate \"" << FmtEscaped(crate.second.m_path) << ".o.mir\";\n";
+            }
+        }
+
+        void finalise(bool is_executable, const TransOptions& opt) override
+        {
+            if( is_executable )
+            {
+                m_of << "fn main(i32, *const *const i8): i32 {\n";
+                m_of << "\t0: {\n";
+                auto c_start_path = m_resolve.m_crate.get_lang_item_path_opt("mrustc-start");
+                if( c_start_path == ::HIR::SimplePath() )
+                {
+                    m_of << "\tlet m: fn();";
+                    m_of << "\t0: {\n";
+                    m_of << "\t\tASSIGN m = " << Trans_Mangle( ::HIR::GenericPath(m_resolve.m_crate.get_lang_item_path(Span(), "mrustc-main")) ) << "\n";
+                    m_of << "\t\tCALL RETURN = " << Trans_Mangle(::HIR::GenericPath(c_start_path)) << "(m, arg1, arg2) goto 1 else 1;\n";
+                }
+                else
+                {
+                    m_of << "\t0: {\n";
+                    m_of << "\t\tCALL RETURN = " << Trans_Mangle(::HIR::GenericPath(c_start_path)) << "(arg1, arg2) goto 1 else 1;\n";
+                }
+                m_of << "\t}\n";
+                m_of << "\t1: {\n";
+                m_of << "\t\tRETURN}\n";
+                m_of << "\t}\n";
+                m_of << "}\n";
+            }
+
+            m_of.flush();
+            m_of.close();
+        }
+
+        /*
+        void emit_box_drop_glue(::HIR::GenericPath p, const ::HIR::Struct& item)
+        {
+            auto struct_ty = ::HIR::TypeRef( p.clone(), &item );
+            auto drop_glue_path = ::HIR::Path(struct_ty.clone(), "#drop_glue");
+            auto struct_ty_ptr = ::HIR::TypeRef::new_borrow(::HIR::BorrowType::Owned, struct_ty.clone());
+            // - Drop Glue
+            const auto* ity = m_resolve.is_type_owned_box(struct_ty);
+
+            auto inner_ptr = ::HIR::TypeRef::new_pointer( ::HIR::BorrowType::Unique, ity->clone() );
+            auto box_free = ::HIR::GenericPath { m_crate.get_lang_item_path(sp, "box_free"), { ity->clone() } };
+
+            ::std::vector< ::std::pair<::HIR::Pattern,::HIR::TypeRef> > args;
+            args.push_back( ::std::make_pair( ::HIR::Pattern {}, mv$(inner_ptr) ) );
+
+            ::MIR::Function empty_fcn;
+            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, args, empty_fcn };
+            m_mir_res = &mir_res;
+            m_of << "fn " << Trans_Mangle(drop_glue_path) << "(" << Trans_Mangle(p) << ") {\n";
+
+            // Obtain inner pointer
+            // TODO: This is very specific to the structure of the official liballoc's Box.
+            m_of << "\tlet arg1: "; emit_type(args[0].second); m_of << "\n";
+            // Call destructor of inner data
+            emit_destructor_call( ::MIR::LValue::make_Deref({ box$(::MIR::LValue::make_Argument({0})) }), *ity, true, 1);
+            // Emit a call to box_free for the type
+            m_of << "\t" << Trans_Mangle(box_free) << "(arg0);\n";
+
+            m_of << "}\n";
+            m_mir_res = nullptr;
+        }
+        */
+
+
+        void emit_type(const ::HIR::TypeRef& ty) override
+        {
+            TRACE_FUNCTION_F(ty);
+            ::MIR::Function empty_fcn;
+            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "type " << ty;), ::HIR::TypeRef(), {}, empty_fcn };
+            m_mir_res = &top_mir_res;
+
+            if( const auto* te = ty.m_data.opt_Tuple() )
+            {
+#if 0
+                if( te->size() > 0 )
+                {
+                    m_of << "typedef struct "; emit_ctype(ty); m_of << " {\n";
+                    for(unsigned int i = 0; i < te.size(); i++)
+                    {
+                        m_of << "\t";
+                        emit_ctype(te[i], FMT_CB(ss, ss << "_" << i;));
+                        m_of << ";\n";
+                    }
+                    m_of << "} "; emit_ctype(ty); m_of << ";\n";
+                }
+
+                auto drop_glue_path = ::HIR::Path(ty.clone(), "#drop_glue");
+                auto args = ::std::vector< ::std::pair<::HIR::Pattern,::HIR::TypeRef> >();
+                auto ty_ptr = ::HIR::TypeRef::new_pointer(::HIR::BorrowType::Owned, ty.clone());
+                ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), ty_ptr, args, empty_fcn };
+                m_mir_res = &mir_res;
+                m_of << "static void " << Trans_Mangle(drop_glue_path) << "("; emit_ctype(ty); m_of << "* rv) {";
+                auto self = ::MIR::LValue::make_Deref({ box$(::MIR::LValue::make_Return({})) });
+                auto fld_lv = ::MIR::LValue::make_Field({ box$(self), 0 });
+                for(const auto& ity : te)
+                {
+                    emit_destructor_call(fld_lv, ity, /*unsized_valid=*/false, 1);
+                    fld_lv.as_Field().field_index ++;
+                }
+                m_of << "}\n";
+#endif
+            }
+            else {
+            }
+
+            m_mir_res = nullptr;
+        }
+
+        void emit_struct(const Span& sp, const ::HIR::GenericPath& p, const ::HIR::Struct& item) override
+        {
+            ::MIR::Function empty_fcn;
+            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "struct " << p;), ::HIR::TypeRef(), {}, empty_fcn };
+            m_mir_res = &top_mir_res;
+
+            bool is_vtable; {
+                const auto& lc = p.m_path.m_components.back();
+                is_vtable = (lc.size() > 7 && ::std::strcmp(lc.c_str() + lc.size() - 7, "#vtable") == 0);
+            };
+
+            TRACE_FUNCTION_F(p);
+            ::HIR::TypeRef  ty = ::HIR::TypeRef::new_path(p.clone(), &item);
+
+            // HACK: For vtables, insert the alignment and size at the start
+            // TODO: Add this to the vtable in the HIR instead
+            if(is_vtable)
+            {
+                //m_of << "\tVTABLE_HDR hdr;\n";
+            }
+
+            const auto* repr = Target_GetTypeRepr(sp, m_resolve, ty);
+            MIR_ASSERT(*m_mir_res, repr, "No repr for struct " << ty);
+            m_of << "type " << p << " {\n";
+            m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
+            size_t  ofs = 0;
+            for(const auto& e : repr->fields)
+            {
+                m_of << "\t" << e.offset << " = " << e.ty << ";\n";
+            }
+            m_of << "}\n";
+
+            // TODO: Drop glue!
+#if 0
+            auto struct_ty = ::HIR::TypeRef(p.clone(), &item);
+            auto drop_glue_path = ::HIR::Path(struct_ty.clone(), "#drop_glue");
+            auto struct_ty_ptr = ::HIR::TypeRef::new_borrow(::HIR::BorrowType::Owned, struct_ty.clone());
+            // - Drop Glue
+
+            ::std::vector< ::std::pair<::HIR::Pattern,::HIR::TypeRef> > args;
+            if( item.m_markings.has_drop_impl ) {
+                // If the type is defined outside the current crate, define as static (to avoid conflicts when we define it)
+                if( p.m_path.m_crate_name != m_crate.m_crate_name )
+                {
+                    if( item.m_params.m_types.size() > 0 ) {
+                        m_of << "static ";
+                    }
+                    else {
+                        m_of << "extern ";
+                    }
+                }
+                m_of << "tUNIT " << Trans_Mangle( ::HIR::Path(struct_ty.clone(), m_resolve.m_lang_Drop, "drop") ) << "("; emit_ctype(struct_ty_ptr, FMT_CB(ss, ss << "rv";)); m_of << ");\n";
+            }
+            else if( m_resolve.is_type_owned_box(struct_ty) )
+            {
+                m_box_glue_todo.push_back( ::std::make_pair( mv$(struct_ty.m_data.as_Path().path.m_data.as_Generic()), &item ) );
+                m_of << "static void " << Trans_Mangle(drop_glue_path) << "("; emit_ctype(struct_ty_ptr, FMT_CB(ss, ss << "rv";)); m_of << ");\n";
+                return ;
+            }
+
+            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, args, empty_fcn };
+            m_mir_res = &mir_res;
+            m_of << "static void " << Trans_Mangle(drop_glue_path) << "("; emit_ctype(struct_ty_ptr, FMT_CB(ss, ss << "rv";)); m_of << ") {\n";
+
+            // If this type has an impl of Drop, call that impl
+            if( item.m_markings.has_drop_impl ) {
+                m_of << "\t" << Trans_Mangle( ::HIR::Path(struct_ty.clone(), m_resolve.m_lang_Drop, "drop") ) << "(rv);\n";
+            }
+
+            auto self = ::MIR::LValue::make_Deref({ box$(::MIR::LValue::make_Return({})) });
+            auto fld_lv = ::MIR::LValue::make_Field({ box$(self), 0 });
+            TU_MATCHA( (item.m_data), (e),
+            (Unit,
+                ),
+            (Tuple,
+                for(unsigned int i = 0; i < e.size(); i ++)
+                {
+                    const auto& fld = e[i];
+                    fld_lv.as_Field().field_index = i;
+
+                    emit_destructor_call(fld_lv, monomorph(fld.ent), true, 1);
+                }
+                ),
+            (Named,
+                for(unsigned int i = 0; i < e.size(); i ++)
+                {
+                    const auto& fld = e[i].second;
+                    fld_lv.as_Field().field_index = i;
+
+                    emit_destructor_call(fld_lv, monomorph(fld.ent), true, 1);
+                }
+                )
+            )
+            m_of << "}\n";
+#endif
+            m_mir_res = nullptr;
+        }
+        void emit_union(const Span& sp, const ::HIR::GenericPath& p, const ::HIR::Union& item) override
+        {
+            ::MIR::Function empty_fcn;
+            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "union " << p;), ::HIR::TypeRef(), {}, empty_fcn };
+            m_mir_res = &top_mir_res;
+
+            TRACE_FUNCTION_F(p);
+            ::HIR::TypeRef  ty = ::HIR::TypeRef::new_path(p.clone(), &item);
+
+            const auto* repr = Target_GetTypeRepr(sp, m_resolve, ty);
+            MIR_ASSERT(*m_mir_res, repr, "No repr for union " << ty);
+            m_of << "type " << p << " {\n";
+            m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
+            size_t  ofs = 0;
+            for(const auto& e : repr->fields)
+            {
+                m_of << "\t" << e.offset << " = " << e.ty << ";\n";
+            }
+            m_of << "}\n";
+
+            // TODO: Drop glue!
+#if 0
+            // Drop glue (calls destructor if there is one)
+            auto item_ty = ::HIR::TypeRef(p.clone(), &item);
+            auto drop_glue_path = ::HIR::Path(item_ty.clone(), "#drop_glue");
+            auto item_ptr_ty = ::HIR::TypeRef::new_borrow(::HIR::BorrowType::Owned, item_ty.clone());
+            auto drop_impl_path = (item.m_markings.has_drop_impl ? ::HIR::Path(item_ty.clone(), m_resolve.m_lang_Drop, "drop") : ::HIR::Path(::HIR::SimplePath()));
+            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), item_ptr_ty, {}, empty_fcn };
+            m_mir_res = &mir_res;
+
+            if( item.m_markings.has_drop_impl )
+            {
+                m_of << "tUNIT " << Trans_Mangle(drop_impl_path) << "(union u_" << Trans_Mangle(p) << "*rv);\n";
+            }
+
+            m_of << "static void " << Trans_Mangle(drop_glue_path) << "(union u_" << Trans_Mangle(p) << "* rv) {\n";
+            if( item.m_markings.has_drop_impl )
+            {
+                m_of << "\t" << Trans_Mangle(drop_impl_path) << "(rv);\n";
+            }
+            m_of << "}\n";
+#endif
+        }
+
+        void emit_enum(const Span& sp, const ::HIR::GenericPath& p, const ::HIR::Enum& item) override
+        {
+            ::MIR::Function empty_fcn;
+            ::MIR::TypeResolve  top_mir_res { sp, m_resolve, FMT_CB(ss, ss << "enum " << p;), ::HIR::TypeRef(), {}, empty_fcn };
+            m_mir_res = &top_mir_res;
+
+
+            TRACE_FUNCTION_F(p);
+            ::HIR::TypeRef  ty = ::HIR::TypeRef::new_path(p.clone(), &item);
+
+            const auto* repr = Target_GetTypeRepr(sp, m_resolve, ty);
+            MIR_ASSERT(*m_mir_res, repr, "No repr for enum " << ty);
+            m_of << "type " << p << " {\n";
+            m_of << "\tSIZE " << repr->size << ", ALIGN " << repr->align << ";\n";
+            size_t  ofs = 0;
+            for(const auto& e : repr->fields)
+            {
+                m_of << "\t" << e.offset << " = " << e.ty << ";\n";
+            }
+            switch(repr->variants.tag())
+            {
+            case TypeRepr::VariantMode::TAGDEAD:    throw "";
+            TU_ARM(repr->variants, None, e)
+                break;
+            TU_ARM(repr->variants, Values, e)
+                for(auto v : e.values)
+                {
+                    m_of << "\t[" << e.field.index << ", " << e.field.sub_fields << "] = \"";
+                    for(size_t i = 0; i < e.field.size; i ++)
+                    {
+                        int val = (v >> (i*8)) & 0xFF;
+                        //if( val == 0 )
+                        //    m_of << "\\0";
+                        //else
+                        if(val < 16)
+                            m_of << ::std::hex << "\\x0" << val << ::std::dec;
+                        else
+                            m_of << ::std::hex << "\\x" << val << ::std::dec;
+                    }
+                    m_of << "\";\n";
+                }
+                break;
+            TU_ARM(repr->variants, NonZero, e) {
+                m_of << "\t[" << e.field.index << ", " << e.field.sub_fields << "] = \"";
+                for(size_t i = 0; i < e.field.size; i ++)
+                {
+                    m_of << "\\0";
+                }
+                m_of << "\";\n";
+                } break;
+            }
+            m_of << "}\n";
+
+#if 0
+            // ---
+            // - Drop Glue
+            // ---
+            auto struct_ty = ::HIR::TypeRef(p.clone(), &item);
+            auto drop_glue_path = ::HIR::Path(struct_ty.clone(), "#drop_glue");
+            auto struct_ty_ptr = ::HIR::TypeRef::new_borrow(::HIR::BorrowType::Owned, struct_ty.clone());
+            auto drop_impl_path = (item.m_markings.has_drop_impl ? ::HIR::Path(struct_ty.clone(), m_resolve.m_lang_Drop, "drop") : ::HIR::Path(::HIR::SimplePath()));
+            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << drop_glue_path;), struct_ty_ptr, {}, empty_fcn };
+            m_mir_res = &mir_res;
+
+            if( item.m_markings.has_drop_impl )
+            {
+                m_of << "tUNIT " << Trans_Mangle(drop_impl_path) << "(struct e_" << Trans_Mangle(p) << "*rv);\n";
+            }
+
+            m_of << "static void " << Trans_Mangle(drop_glue_path) << "(struct e_" << Trans_Mangle(p) << "* rv) {\n";
+
+            // If this type has an impl of Drop, call that impl
+            if( item.m_markings.has_drop_impl )
+            {
+                m_of << "\t" << Trans_Mangle(drop_impl_path) << "(rv);\n";
+            }
+            auto self = ::MIR::LValue::make_Deref({ box$(::MIR::LValue::make_Return({})) });
+
+            if( nonzero_path.size() > 0 )
+            {
+                // TODO: Fat pointers?
+                m_of << "\tif( (*rv)._1"; emit_nonzero_path(nonzero_path); m_of << " ) {\n";
+                emit_destructor_call( ::MIR::LValue::make_Field({ box$(self), 1 }), monomorph(item.m_data.as_Data()[1].type), false, 2 );
+                m_of << "\t}\n";
+            }
+            else if( const auto* e = item.m_data.opt_Data() )
+            {
+                auto var_lv =::MIR::LValue::make_Downcast({ box$(self), 0 });
+
+                m_of << "\tswitch(rv->TAG) {\n";
+                for(unsigned int var_idx = 0; var_idx < e->size(); var_idx ++)
+                {
+                    var_lv.as_Downcast().variant_index = var_idx;
+                    m_of << "\tcase " << var_idx << ":\n";
+                    emit_destructor_call(var_lv, monomorph( (*e)[var_idx].type ), false, 2);
+                    m_of << "\tbreak;\n";
+                }
+                m_of << "\t}\n";
+            }
+            else
+            {
+                // Value enum
+                // Glue does nothing (except call the destructor, if there is one)
+            }
+            m_of << "}\n";
+
+            if( nonzero_path.size() )
+            {
+                m_enum_repr_cache.insert( ::std::make_pair( p.clone(), mv$(nonzero_path) ) );
+            }
+#endif
+            m_mir_res = nullptr;
+        }
+        void emit_function_code(const ::HIR::Path& p, const ::HIR::Function& item, const Trans_Params& params, bool is_extern_def, const ::MIR::FunctionPointer& code) override
+        {
+            TRACE_FUNCTION_F(p);
+
+            ::MIR::TypeResolve::args_t  arg_types;
+            for(const auto& ent : item.m_args)
+                arg_types.push_back(::std::make_pair( ::HIR::Pattern{}, params.monomorph(m_resolve, ent.second) ));
+
+            ::HIR::TypeRef  ret_type_tmp;
+            const auto& ret_type = monomorphise_fcn_return(ret_type_tmp, item, params);
+
+            ::MIR::TypeResolve  mir_res { sp, m_resolve, FMT_CB(ss, ss << p;), ret_type, arg_types, *code };
+            m_mir_res = &mir_res;
+
+            m_of << "fn " << p << "(";
+            m_of << "): " << ret_type << " {\n";
+            for(unsigned int i = 0; i < code->locals.size(); i ++) {
+                DEBUG("var" << i << " : " << code->locals[i]);
+                m_of << "\tlet var" << i << ": " << code->locals[i] << ";\n";
+            }
+            for(unsigned int i = 0; i < code->drop_flags.size(); i ++) {
+                m_of << "\tlet df" << i << " = " << code->drop_flags[i] << ";\n";
+            }
+
+            
+            for(unsigned int i = 0; i < code->blocks.size(); i ++)
+            {
+                TRACE_FUNCTION_F(p << " bb" << i);
+
+                m_of << "\t" << i << ": {\n";
+
+                for(const auto& stmt : code->blocks[i].statements)
+                {
+                    m_of << "\t\t";
+                    mir_res.set_cur_stmt(i, (&stmt - &code->blocks[i].statements.front()));
+                    DEBUG(stmt);
+                    switch(stmt.tag())
+                    {
+                    case ::MIR::Statement::TAGDEAD: throw "";
+                    TU_ARM(stmt, Assign, se) {
+                        m_of << "ASSIGN " << fmt(se.dst) << " = ";
+                        switch(se.src.tag())
+                        {
+                        case ::MIR::RValue::TAGDEAD:    throw "";
+                        TU_ARM(se.src, Use, e)
+                            m_of << "=" << fmt(e);
+                            break;
+                        TU_ARM(se.src, Constant, e)
+                            m_of << e;
+                            break;
+                        TU_ARM(se.src, SizedArray, e)
+                            m_of << "[" << fmt(e.val) << "; " << e.count << "]";
+                            break;
+                        TU_ARM(se.src, Borrow, e) {
+                            m_of << "&";
+                            switch(e.type)
+                            {
+                            case ::HIR::BorrowType::Shared: break;
+                            case ::HIR::BorrowType::Unique: m_of << "mut "; break;
+                            case ::HIR::BorrowType::Owned:  m_of << "move "; break;
+                            }
+                            m_of << fmt(e.val);
+                            } break;
+                        TU_ARM(se.src, Cast, e)
+                            m_of << "CAST " << fmt(e.val) << " as " << e.type;
+                            break;
+                        TU_ARM(se.src, BinOp, e) {
+                            m_of << "BINOP " << fmt(e.val_l) << " ";
+                            switch(e.op)
+                            {
+                            case ::MIR::eBinOp::ADD:    m_of << "+";    break;
+                            case ::MIR::eBinOp::ADD_OV: m_of << "+^";   break;
+                            case ::MIR::eBinOp::SUB:    m_of << "-";    break;
+                            case ::MIR::eBinOp::SUB_OV: m_of << "-^";   break;
+                            case ::MIR::eBinOp::MUL:    m_of << "*";    break;
+                            case ::MIR::eBinOp::MUL_OV: m_of << "*^";   break;
+                            case ::MIR::eBinOp::DIV:    m_of << "*";    break;
+                            case ::MIR::eBinOp::DIV_OV: m_of << "*^";   break;
+                            case ::MIR::eBinOp::MOD:    m_of << "%";    break;
+                            case ::MIR::eBinOp::BIT_OR: m_of << "|";    break;
+                            case ::MIR::eBinOp::BIT_AND:m_of << "&";    break;
+                            case ::MIR::eBinOp::BIT_XOR:m_of << "^";    break;
+                            case ::MIR::eBinOp::BIT_SHR:m_of << ">>";   break;
+                            case ::MIR::eBinOp::BIT_SHL:m_of << "<<";   break;
+                            case ::MIR::eBinOp::NE:     m_of << "!=";   break;
+                            case ::MIR::eBinOp::EQ:     m_of << "==";   break;
+                            case ::MIR::eBinOp::GT:     m_of << ">" ;   break;
+                            case ::MIR::eBinOp::GE:     m_of << ">=";   break;
+                            case ::MIR::eBinOp::LT:     m_of << "<" ;   break;
+                            case ::MIR::eBinOp::LE:     m_of << "<=";   break;
+                            }
+                            m_of << " " << fmt(e.val_r);
+                            } break;
+                        TU_ARM(se.src, UniOp, e) {
+                            m_of << "UNIOP ";
+                            switch(e.op)
+                            {
+                            case ::MIR::eUniOp::INV:    m_of << "!";    break;
+                            case ::MIR::eUniOp::NEG:    m_of << "-";    break;
+                            }
+                            m_of << " " << fmt(e.val);
+                            } break;
+                        TU_ARM(se.src, DstMeta, e)
+                            m_of << "DSTMETA " << fmt(e.val);
+                            break;
+                        TU_ARM(se.src, DstPtr, e)
+                            m_of << "DSTPTR " << fmt(e.val);
+                            break;
+                        TU_ARM(se.src, MakeDst, e)
+                            m_of << "MAKEDST " << fmt(e.ptr_val) << ", " << fmt(e.ptr_val);
+                            break;
+                        TU_ARM(se.src, Variant, e)
+                            m_of << "VARIANT " << e.path << " " << e.index << " " << fmt(e.val);
+                            break;
+                        TU_ARM(se.src, Array, e) {
+                            m_of << "[ ";
+                            for(const auto& v : e.vals)
+                            {
+                                m_of << fmt(v) << ", ";
+                            }
+                            m_of << "]";
+                            } break;
+                        TU_ARM(se.src, Tuple, e) {
+                            m_of << "( ";
+                            for(const auto& v : e.vals)
+                            {
+                                m_of << fmt(v) << ", ";
+                            }
+                            m_of << ")";
+                            } break;
+                        TU_ARM(se.src, Struct, e) {
+                            m_of << "{ ";
+                            for(const auto& v : e.vals)
+                            {
+                                m_of << fmt(v) << ", ";
+                            }
+                            m_of << "}: " << e.path;
+                            } break;
+                        }
+                        } break;
+                    TU_ARM(stmt, SetDropFlag, se) {
+                        m_of << "SETFLAG df" << se.idx << " = ";
+                        if( se.other == ~0u )
+                        {
+                            m_of << se.new_val;
+                        }
+                        else
+                        {
+                            m_of << (se.new_val ? "" : "!") << "df" << se.other;
+                        }
+                        } break;
+                    TU_ARM(stmt, Asm, se) {
+                        m_of << "ASM (";
+                        for(const auto& v : se.outputs)
+                        {
+                            m_of << "\"" << v.first << "\" : " << fmt(v.second) << ", ";
+                        }
+                        m_of << ") = \"" << se.tpl << "\"(";
+                        for(const auto& v : se.inputs)
+                        {
+                            m_of << "\"" << v.first << "\" : " << fmt(v.second) << ", ";
+                        }
+                        m_of << ") [" << se.flags << "]";
+                        } break;
+                    TU_ARM(stmt, ScopeEnd, se) {
+                        continue ;
+                        } break;
+                    TU_ARM(stmt, Drop, se) {
+                        m_of << "DROP " << fmt(se.slot);
+                        switch(se.kind)
+                        {
+                        case ::MIR::eDropKind::DEEP:
+                            break;
+                        case ::MIR::eDropKind::SHALLOW:
+                            m_of << " SHALLOW";
+                            break;
+                        }
+                        if(se.flag_idx != ~0u)
+                        {
+                            m_of << " IF df" << se.flag_idx;
+                        }
+                        } break;
+                    }
+                    m_of << ";\n";
+                }
+
+                mir_res.set_cur_stmt_term(i);
+                const auto& term = code->blocks[i].terminator;
+                DEBUG("- " << term);
+                m_of << "\t\t";
+                switch(term.tag())
+                {
+                case ::MIR::Terminator::TAGDEAD: throw "";
+                TU_ARM(term, Incomplete, _e)
+                    m_of << "INCOMPLTE\n";
+                    break;
+                TU_ARM(term, Return, _e)
+                    m_of << "RETURN\n";
+                    break;
+                TU_ARM(term, Diverge, _e)
+                    m_of << "DIVERGE\n";
+                    break;
+                TU_ARM(term, Goto, e)
+                    m_of << "GOTO " << e << "\n";
+                    break;
+                TU_ARM(term, Panic, e)
+                    m_of << "PANIC " << e.dst << "\n";
+                    break;
+                TU_ARM(term, If, e)
+                    m_of << "IF " << fmt(e.cond) << " goto " << e.bb0 << " else " << e.bb1 << "\n";
+                    break;
+                TU_ARM(term, Switch, e) {
+                    m_of << "SWITCH " << fmt(e.val) << " { ";
+                    m_of << e.targets;
+                    m_of << " }\n";
+                    } break;
+                TU_ARM(term, SwitchValue, e) {
+                    m_of << "SWITCHVALUE " << fmt(e.val) << " { ";
+                    // TODO: Values.
+                    //if( e.values.size() > 0 )
+                    //{
+                    //    m_of << ", ";
+                    //}
+                    m_of << "_ = " << e.def_target;
+                    m_of << " }\n";
+                    } break;
+                TU_ARM(term, Call, e) {
+                    m_of << "CALL " << fmt(e.ret_val) << " = ";
+                    switch(e.fcn.tag())
+                    {
+                    case ::MIR::CallTarget::TAGDEAD: throw "";
+                    TU_ARM(e.fcn, Intrinsic, f) m_of << "\"" << f.name << "\"" << f.params;  break;
+                    TU_ARM(e.fcn, Value, f)     m_of << "(" << fmt(f) << ")";  break;
+                    TU_ARM(e.fcn, Path, f)      m_of << f;  break;
+                    }
+                    m_of << "(";
+                    for(const auto& a : e.args)
+                    {
+                        m_of << fmt(a) << ", ";
+                    }
+                    m_of << ") goto " << e.ret_block << " else " << e.panic_block << "\n";
+                    } break;
+                }
+                m_of << "\t}\n";
+            }
+
+            m_of << "}\n";
+
+
+            m_mir_res = nullptr;
+        }
+
+
+    private:
+        const ::HIR::TypeRef& monomorphise_fcn_return(::HIR::TypeRef& tmp, const ::HIR::Function& item, const Trans_Params& params)
+        {
+            if( visit_ty_with(item.m_return, [&](const auto& x){ return x.m_data.is_ErasedType() || x.m_data.is_Generic(); }) )
+            {
+                tmp = clone_ty_with(Span(), item.m_return, [&](const auto& tpl, auto& out) {
+                    TU_IFLET( ::HIR::TypeRef::Data, tpl.m_data, ErasedType, e,
+                        out = params.monomorph(m_resolve, item.m_code.m_erased_types.at(e.m_index));
+                        return true;
+                    )
+                    else if( tpl.m_data.is_Generic() ) {
+                        out = params.get_cb()(tpl).clone();
+                        return true;
+                    }
+                    else {
+                        return false;
+                    }
+                });
+                m_resolve.expand_associated_types(Span(), tmp);
+                return tmp;
+            }
+            else
+            {
+                return item.m_return;
+            }
+        }
+    };
+    Span CodeGenerator_MonoMir::sp;
+}
+
+::std::unique_ptr<CodeGenerator> Trans_Codegen_GetGenerator_MonoMir(const ::HIR::Crate& crate, const ::std::string& outfile)
+{
+    return ::std::unique_ptr<CodeGenerator>(new CodeGenerator_MonoMir(crate, outfile));
+}

--- a/src/trans/main_bindings.hpp
+++ b/src/trans/main_bindings.hpp
@@ -15,6 +15,7 @@ class Crate;
 
 struct TransOptions
 {
+    ::std::string   mode = "c";
     unsigned int opt_level = 0;
     bool emit_debug_info = false;
     ::std::string   build_command_file;

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -137,6 +137,7 @@ namespace {
     // Returns NULL when the repr can't be determined
     ::std::unique_ptr<StructRepr> make_struct_repr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
     {
+        TRACE_FUNCTION_F(ty);
         ::std::vector<StructRepr::Ent>  ents;
         bool packed = false;
         bool allow_sort = false;
@@ -160,6 +161,8 @@ namespace {
                     size_t  size, align;
                     if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size,align) )
                         return nullptr;
+                    if( size == SIZE_MAX )
+                        BUG(sp, "Unsized type in tuple struct");
                     ents.push_back(StructRepr::Ent { idx++, size, align, mv$(ty) });
                 }
                 ),
@@ -171,6 +174,8 @@ namespace {
                     size_t  size, align;
                     if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size,align) )
                         return nullptr;
+                    if( size == SIZE_MAX )
+                        BUG(sp, "Unsized type in struct");
                     ents.push_back(StructRepr::Ent { idx++, size, align, mv$(ty) });
                 }
                 )
@@ -197,6 +202,8 @@ namespace {
                 size_t  size, align;
                 if( !Target_GetSizeAndAlignOf(sp, resolve, t, size,align) )
                     return nullptr;
+                if( size == SIZE_MAX )
+                    BUG(sp, "Unsized type in tuple");
                 ents.push_back(StructRepr::Ent { idx++, size, align, t.clone() });
             }
         }
@@ -316,52 +323,33 @@ bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve,
             out_align = 8;
             return true;
         case ::HIR::CoreType::Str:
-            BUG(sp, "sizeof on a `str` - unsized");
+            DEBUG("sizeof on a `str` - unsized");
+            out_size  = SIZE_MAX;
+            out_align = 1;
+            return true;
         }
         ),
     (Path,
-        TU_MATCHA( (te.binding), (be),
-        (Unbound,
-            BUG(sp, "Unbound type path " << ty << " encountered");
-            ),
-        (Opaque,
+        const auto* repr = Target_GetTypeRepr(sp, resolve, ty);
+        if( !repr )
+        {
+            DEBUG("Cannot get type repr for " << ty);
             return false;
-            ),
-        (Struct,
-            if( const auto* repr = Target_GetStructRepr(sp, resolve, ty) )
-            {
-                out_size = 0;
-                out_align = 1;
-                for(const auto& e : repr->ents)
-                {
-                    out_size += e.size;
-                    out_align = ::std::max(out_align, e.align);
-                }
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-            ),
-        (Enum,
-            // Search for alternate repr
-            // If not found, determine the variant size
-            // Get data size and alignment.
-            return false;
-            ),
-        (Union,
-            // Max alignment and max data size
-            return false;
-            )
-        )
+        }
+        out_size  = repr->size;
+        out_align = repr->align;
+        return true;
         ),
     (Generic,
         // Unknown - return false
+        DEBUG("No repr for Generic - " << ty);
         return false;
         ),
     (TraitObject,
-        BUG(sp, "sizeof on a trait object - unsized");
+        out_align = 0;
+        out_size = SIZE_MAX;
+        DEBUG("sizeof on a trait object - unsized");
+        return true;
         ),
     (ErasedType,
         BUG(sp, "sizeof on an erased type - shouldn't exist");
@@ -370,28 +358,37 @@ bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve,
         size_t  size;
         if( !Target_GetSizeAndAlignOf(sp, resolve, *te.inner, size,out_align) )
             return false;
-        size *= te.size_val;
-        ),
-    (Slice,
-        BUG(sp, "sizeof on a slice - unsized");
-        ),
-    (Tuple,
-        // Same code as structs :)
-        if( const auto* repr = Target_GetStructRepr(sp, resolve, ty) )
+        if( size == SIZE_MAX )
+            BUG(sp, "Unsized type in array - " << ty);
+        if( te.size_val == 0 )
         {
-            out_size = 0;
-            out_align = 1;
-            for(const auto& e : repr->ents)
-            {
-                out_size += e.size;
-                out_align = ::std::max(out_align, e.align);
-            }
-            return true;
+            size = 0;
         }
         else
         {
+            if( SIZE_MAX / te.size_val <= size )
+                BUG(sp, "Integer overflow calculating array size");
+            size *= te.size_val;
+        }
+        return true;
+        ),
+    (Slice,
+        if( !Target_GetAlignOf(sp, resolve, *te.inner, out_align) )
+            return false;
+        out_size = SIZE_MAX;
+        DEBUG("sizeof on a slice - unsized");
+        return true;
+        ),
+    (Tuple,
+        const auto* repr = Target_GetTypeRepr(sp, resolve, ty);
+        if( !repr )
+        {
+            DEBUG("Cannot get type repr for " << ty);
             return false;
         }
+        out_size  = repr->size;
+        out_align = repr->align;
+        return true;
         ),
     (Borrow,
         // - Alignment is machine native
@@ -427,6 +424,7 @@ bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve,
         ),
     (Closure,
         // TODO.
+        DEBUG("TODO Closure - " << ty);
         )
     )
     return false;
@@ -434,10 +432,441 @@ bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve,
 bool Target_GetSizeOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_size)
 {
     size_t  ignore_align;
-    return Target_GetSizeAndAlignOf(sp, resolve, ty, out_size, ignore_align);
+    bool rv = Target_GetSizeAndAlignOf(sp, resolve, ty, out_size, ignore_align);
+    if( out_size == SIZE_MAX )
+        BUG(sp, "Getting size of Unsized type - " << ty);
+    return rv;
 }
 bool Target_GetAlignOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_align)
 {
     size_t  ignore_size;
-    return Target_GetSizeAndAlignOf(sp, resolve, ty, ignore_size, out_align);
+    bool rv = Target_GetSizeAndAlignOf(sp, resolve, ty, ignore_size, out_align);
+    if( ignore_size == SIZE_MAX )
+        BUG(sp, "Getting alignment of Unsized type - " << ty);
+    return rv;
+}
+
+
+namespace {
+    // Returns NULL when the repr can't be determined
+    ::std::unique_ptr<TypeRepr> make_type_repr_struct(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
+    {
+        TRACE_FUNCTION_F(ty);
+        struct Ent {
+            unsigned int field;
+            size_t  size;
+            size_t  align;
+        };
+        ::std::vector<TypeRepr::Field>  fields;
+        ::std::vector<Ent>  ents;
+        bool packed = false;
+        bool allow_sort = false;
+        if( ty.m_data.is_Path() && ty.m_data.as_Path().binding.is_Struct() )
+        {
+            const auto& te = ty.m_data.as_Path();
+            const auto& str = *te.binding.as_Struct();
+            auto monomorph_cb = monomorphise_type_get_cb(sp, nullptr, &te.path.m_data.as_Generic().m_params, nullptr);
+            auto monomorph = [&](const auto& tpl) {
+                auto rv = monomorphise_type_with(sp, tpl, monomorph_cb);
+                resolve.expand_associated_types(sp, rv);
+                return rv;
+                };
+            TU_MATCHA( (str.m_data), (se),
+            (Unit,
+                ),
+            (Tuple,
+                unsigned int idx = 0;
+                for(const auto& e : se)
+                {
+                    auto ty = monomorph(e.ent);
+                    size_t  size, align;
+                    if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size,align) )
+                    {
+                        DEBUG("Can't get size/align of " << ty);
+                        return nullptr;
+                    }
+                    ents.push_back(Ent { idx++, size, align });
+                    fields.push_back(TypeRepr::Field { 0, mv$(ty) });
+                }
+                ),
+            (Named,
+                unsigned int idx = 0;
+                for(const auto& e : se)
+                {
+                    auto ty = monomorph(e.second.ent);
+                    size_t  size, align;
+                    if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size,align) )
+                    {
+                        DEBUG("Can't get size/align of " << ty);
+                        return nullptr;
+                    }
+                    ents.push_back(Ent { idx++, size, align });
+                    fields.push_back(TypeRepr::Field { 0, mv$(ty) });
+                }
+                )
+            )
+            switch(str.m_repr)
+            {
+            case ::HIR::Struct::Repr::Packed:
+                packed = true;
+                TODO(sp, "make_struct_repr - repr(packed)");    // needs codegen help
+                break;
+            case ::HIR::Struct::Repr::C:
+                // No sorting, no packing
+                break;
+            case ::HIR::Struct::Repr::Rust:
+                allow_sort = true;
+                break;
+            }
+        }
+        else if( const auto* te = ty.m_data.opt_Tuple() )
+        {
+            DEBUG("Tuple " << ty);
+            unsigned int idx = 0;
+            for(const auto& t : *te)
+            {
+                size_t  size, align;
+                if( !Target_GetSizeAndAlignOf(sp, resolve, t, size,align) )
+                {
+                    DEBUG("Can't get size/align of " << t);
+                    return nullptr;
+                }
+                if( size == SIZE_MAX )
+                {
+                    TODO(sp, "Unsized type in struct - " << t);
+                }
+                ents.push_back(Ent { idx++, size, align });
+                fields.push_back(TypeRepr::Field { 0, t.clone() });
+            }
+        }
+        else
+        {
+            BUG(sp, "Unexpected type in creating type repr - " << ty);
+        }
+
+
+        if( allow_sort )
+        {
+            // TODO: Sort by alignment then size (largest first)
+            // - Requires codegen to use this information
+            // - NOTE: ?Sized fields (which includes unsized fields) MUST be at the end, even after monomorph
+        }
+
+        TypeRepr  rv;
+        size_t  cur_ofs = 0;
+        size_t  max_align = 1;
+        for(const auto& e : ents)
+        {
+            // Increase offset to fit alignment
+            if( !packed && e.align > 0 )
+            {
+                while( cur_ofs % e.align != 0 )
+                {
+                    cur_ofs ++;
+                }
+            }
+            max_align = ::std::max(max_align, e.align);
+
+            fields[e.field].offset = cur_ofs;
+            if( e.size == SIZE_MAX )
+            {
+                // TODO: Ensure that this is the last item
+                ASSERT_BUG(sp, &e == &ents.back(), "Unsized item isn't the last item");
+                cur_ofs = SIZE_MAX;
+            }
+            else
+            {
+                cur_ofs += e.size;
+            }
+        }
+        if( !packed && cur_ofs != SIZE_MAX )
+        {
+            while( cur_ofs % max_align != 0 )
+            {
+                cur_ofs ++;
+            }
+        }
+        rv.align = max_align;
+        rv.size = cur_ofs;
+        rv.fields = ::std::move(fields);
+        DEBUG("size = " << rv.size << ", align = " << rv.align);
+        return box$(rv);
+    }
+
+
+    bool get_nonzero_path(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, TypeRepr::FieldPath& out_path)
+    {
+        switch(ty.m_data.tag())
+        {
+        TU_ARM(ty.m_data, Path, te) {
+            if( te.binding.is_Struct() )
+            {
+                const TypeRepr* r = Target_GetTypeRepr(sp, resolve, ty);
+                if( !r )
+                {
+                    return false;
+                }
+                for(size_t i = 0; i < r->fields.size(); i ++)
+                {
+                    if( get_nonzero_path(sp, resolve, r->fields[i].ty, out_path) )
+                    {
+                        out_path.sub_fields.push_back(i);
+                        return true;
+                    }
+                }
+            }
+            } break;
+        TU_ARM(ty.m_data, Borrow, te) {
+            out_path.sub_fields.push_back(0);
+            Target_GetSizeOf(sp, resolve, ty, out_path.size);
+            return true;
+            } break;
+        TU_ARM(ty.m_data, Function, _te)
+            out_path.sub_fields.push_back(0);
+            Target_GetSizeOf(sp, resolve, ty, out_path.size);
+            return true;
+        default:
+            break;
+        }
+        return false;
+    }
+    ::std::unique_ptr<TypeRepr> make_type_repr_enum(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
+    {
+        const auto& te = ty.m_data.as_Path();
+        const auto& enm = *te.binding.as_Enum();
+
+        auto monomorph_cb = monomorphise_type_get_cb(sp, nullptr, &te.path.m_data.as_Generic().m_params, nullptr);
+        auto monomorph = [&](const auto& tpl) {
+            auto rv = monomorphise_type_with(sp, tpl, monomorph_cb);
+            resolve.expand_associated_types(sp, rv);
+            return rv;
+        };
+
+        TypeRepr  rv;
+        switch(enm.m_data.tag())
+        {
+        case ::HIR::Enum::Class::TAGDEAD:   throw "";
+        TU_ARM(enm.m_data, Data, e) {
+            ::std::vector<::HIR::TypeRef>   mono_types;
+            for(const auto& var : e)
+            {
+                mono_types.push_back( monomorph(var.type) );
+            }
+            TypeRepr::FieldPath nz_path;
+            if( e.size() == 2 && mono_types[0] == ::HIR::TypeRef::new_unit() && get_nonzero_path(sp, resolve, mono_types[1], nz_path) )
+            {
+                nz_path.index = 1;
+                ::std::reverse(nz_path.sub_fields.begin(), nz_path.sub_fields.end());
+                size_t  max_size = 0;
+                size_t  max_align = 0;
+                for(auto& t : mono_types)
+                {
+                    size_t  size, align;
+                    if( !Target_GetSizeAndAlignOf(sp, resolve, t, size, align) )
+                    {
+                        DEBUG("Generic type in enum - " << t);
+                        return nullptr;
+                    }
+                    if( size == SIZE_MAX ) {
+                        BUG(sp, "Unsized type in enum - " << t);
+                    }
+                    max_size  = ::std::max(max_size , size);
+                    max_align = ::std::max(max_align, align);
+                    rv.fields.push_back(TypeRepr::Field { 0, mv$(t) });
+                }
+
+                rv.size = max_size;
+                rv.align = max_align;
+                rv.variants = TypeRepr::VariantMode::make_NonZero({ nz_path, 0 });
+            }
+            else
+            {
+                size_t  max_size = 0;
+                size_t  max_align = 0;
+                for(auto& t : mono_types)
+                {
+                    size_t  size, align;
+                    if( !Target_GetSizeAndAlignOf(sp, resolve, t, size, align) )
+                    {
+                        DEBUG("Generic type in enum - " << t);
+                        return nullptr;
+                    }
+                    if( size == SIZE_MAX ) {
+                        BUG(sp, "Unsized type in enum - " << t);
+                    }
+                    max_size  = ::std::max(max_size , size);
+                    max_align = ::std::max(max_align, align);
+                    rv.fields.push_back(TypeRepr::Field { 0, mv$(t) });
+                }
+                size_t tag_size = 0;
+                // TODO: repr(C) enums
+                if( mono_types.size() == 0 ) {
+                    // Unreachable
+                }
+                else if( mono_types.size() == 1 ) {
+                    // No need for a tag
+                }
+                else if( mono_types.size() <= 255 ) {
+                    rv.fields.push_back(TypeRepr::Field { max_size, ::HIR::CoreType::U8 });
+                    tag_size = 1;
+                }
+                else {
+                    ASSERT_BUG(sp, mono_types.size() <= 0xFFFF, "");
+                    while(max_size % 2) max_size ++;
+                    rv.fields.push_back(TypeRepr::Field { max_size, ::HIR::CoreType::U16 });
+                    tag_size = 2;
+                }
+                max_align = ::std::max(max_align, tag_size);
+                ::std::vector<uint64_t> vals;
+                for(size_t i = 0; i < e.size(); i++)
+                {
+                    vals.push_back(i);
+                }
+                rv.variants = TypeRepr::VariantMode::make_Values({ { mono_types.size(), tag_size, {} }, ::std::move(vals) });
+                if( max_align > 0 )
+                {
+                    rv.size = (max_size + tag_size);
+                    while(rv.size % max_align)
+                        rv.size ++;
+                    rv.align = max_align;
+                }
+                else
+                {
+                    ASSERT_BUG(sp, max_size == 0, "Zero alignment, but non-zero size");
+                }
+
+                // TODO: Variants.
+            }
+            } break;
+        TU_ARM(enm.m_data, Value, e) {
+            switch(e.repr)
+            {
+            case ::HIR::Enum::Repr::C:
+                // No auto-sizing, just i32?
+                rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U32 });
+                break;
+            case ::HIR::Enum::Repr::Rust:
+                if( e.variants.size() == 0 ) {
+                }
+                else if( e.variants.size() == 1 ) {
+                }
+                else if( e.variants.size() <= 255 ) {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U8 });
+                }
+                else if( e.variants.size() <= 0xFFFF ) {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U16 });
+                }
+                else if( e.variants.size() <= 0xFFFFFFFF ) {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U32 });
+                }
+                else {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U64 });
+                }
+                break;
+            case ::HIR::Enum::Repr::U8:
+                rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U8 });
+                break;
+            case ::HIR::Enum::Repr::U16:
+                rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U16 });
+                break;
+            case ::HIR::Enum::Repr::U32:
+                rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U32 });
+                break;
+            case ::HIR::Enum::Repr::U64:
+                rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U64 });
+                break;
+            case ::HIR::Enum::Repr::Usize:
+                if( g_target.m_arch.m_pointer_bits == 16 )
+                {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U16 });
+                }
+                else if( g_target.m_arch.m_pointer_bits == 32 )
+                {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U32 });
+                }
+                else if( g_target.m_arch.m_pointer_bits == 64 )
+                {
+                    rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::U64 });
+                }
+                break;
+            }
+            if( rv.fields.size() > 0 )
+            {
+                // Can't return false or unsized
+                Target_GetSizeAndAlignOf(sp, resolve, rv.fields.back().ty, rv.size, rv.align);
+
+                ::std::vector<uint64_t> vals;
+                for(const auto& v : e.variants)
+                {
+                    vals.push_back(v.val);
+                }
+                rv.variants = TypeRepr::VariantMode::make_Values({ 0, rv.size, ::std::move(vals) });
+            }
+            } break;
+        }
+        return box$(rv);
+    }
+    ::std::unique_ptr<TypeRepr> make_type_repr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
+    {
+        TRACE_FUNCTION_F(ty);
+        if( TU_TEST1(ty.m_data, Path, .binding.is_Struct()) || ty.m_data.is_Tuple() )
+        {
+            return make_type_repr_struct(sp, resolve, ty);
+        }
+        else if( TU_TEST1(ty.m_data, Path, .binding.is_Union()) )
+        {
+            const auto& te = ty.m_data.as_Path();
+            const auto& unn = *te.binding.as_Union();
+
+            auto monomorph_cb = monomorphise_type_get_cb(sp, nullptr, &te.path.m_data.as_Generic().m_params, nullptr);
+            auto monomorph = [&](const auto& tpl) {
+                auto rv = monomorphise_type_with(sp, tpl, monomorph_cb);
+                resolve.expand_associated_types(sp, rv);
+                return rv;
+            };
+
+            TypeRepr  rv;
+            for(const auto& var : unn.m_variants)
+            {
+                rv.fields.push_back({ 0, monomorph(var.second.ent) });
+                size_t size, align;
+                if( !Target_GetSizeAndAlignOf(sp, resolve, rv.fields.back().ty, size, align) )
+                {
+                    // Generic? - Not good.
+                    DEBUG("Generic type encounterd after monomorphise in union - " << rv.fields.back().ty);
+                    return nullptr;
+                }
+                if( size == SIZE_MAX ) {
+                    BUG(sp, "Unsized type in union");
+                }
+                rv.size  = ::std::max(rv.size , size );
+                rv.align = ::std::max(rv.align, align);
+            }
+            return box$(rv);
+        }
+        else if( TU_TEST1(ty.m_data, Path, .binding.is_Enum()) )
+        {
+            return make_type_repr_enum(sp, resolve, ty);
+        }
+        else
+        {
+            TODO(sp, "Type repr for " << ty);
+            return nullptr;
+        }
+    }
+}
+const TypeRepr* Target_GetTypeRepr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
+{
+    // TODO: Thread safety
+    // Map of generic types to type representations.
+    static ::std::map<::HIR::TypeRef, ::std::unique_ptr<TypeRepr>>  s_cache;
+
+    auto it = s_cache.find(ty);
+    if( it != s_cache.end() )
+    {
+        return it->second.get();
+    }
+
+    auto ires = s_cache.insert(::std::make_pair( ty.clone(), make_type_repr(sp, resolve, ty) ));
+    return ires.first->second.get();
 }

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -571,7 +571,7 @@ namespace {
             if( e.size == SIZE_MAX )
             {
                 // TODO: Ensure that this is the last item
-                ASSERT_BUG(sp, &e == &ents.back(), "Unsized item isn't the last item");
+                ASSERT_BUG(sp, &e == &ents.back(), "Unsized item isn't the last item in " << ty);
                 cur_ofs = SIZE_MAX;
             }
             else
@@ -617,12 +617,12 @@ namespace {
             }
             } break;
         TU_ARM(ty.m_data, Borrow, _te) { (void)_te;
-            out_path.sub_fields.push_back(0);
+            //out_path.sub_fields.push_back(0);
             Target_GetSizeOf(sp, resolve, ty, out_path.size);
             return true;
             } break;
         TU_ARM(ty.m_data, Function, _te) (void)_te;
-            out_path.sub_fields.push_back(0);
+            //out_path.sub_fields.push_back(0);
             Target_GetSizeOf(sp, resolve, ty, out_path.size);
             return true;
         default:

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -729,7 +729,14 @@ namespace {
                 {
                     vals.push_back(i);
                 }
-                rv.variants = TypeRepr::VariantMode::make_Values({ { mono_types.size(), tag_size, {} }, ::std::move(vals) });
+                if( vals.size() > 1 )
+                {
+                    rv.variants = TypeRepr::VariantMode::make_Values({ { mono_types.size(), tag_size, {} }, ::std::move(vals) });
+                }
+                else
+                {
+                    // Leave the enum with NoVariants
+                }
                 if( max_align > 0 )
                 {
                     rv.size = (max_size + tag_size);
@@ -755,8 +762,7 @@ namespace {
             case ::HIR::Enum::Repr::Rust:
                 if( e.variants.size() == 0 ) {
                 }
-                else if( e.variants.size() == 1 ) {
-                }
+                // NOTE: Even with 1 variant, we need to save the value
                 else if( e.variants.size() <= 128 ) {
                     rv.fields.push_back(TypeRepr::Field { 0, ::HIR::CoreType::I8 });
                 }

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -276,6 +276,7 @@ const StructRepr* Target_GetStructRepr(const Span& sp, const StaticTraitResolve&
 
 bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_size, size_t& out_align)
 {
+    TRACE_FUNCTION_FR(ty, "size=" << out_size << ", align=" << out_align);
     TU_MATCHA( (ty.m_data), (te),
     (Infer,
         BUG(sp, "sizeof on _ type");
@@ -362,20 +363,19 @@ bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve,
         BUG(sp, "sizeof on an erased type - shouldn't exist");
         ),
     (Array,
-        size_t  size;
-        if( !Target_GetSizeAndAlignOf(sp, resolve, *te.inner, size,out_align) )
+        if( !Target_GetSizeAndAlignOf(sp, resolve, *te.inner, out_size,out_align) )
             return false;
-        if( size == SIZE_MAX )
+        if( out_size == SIZE_MAX )
             BUG(sp, "Unsized type in array - " << ty);
-        if( te.size_val == 0 )
+        if( te.size_val == 0 || out_size == 0 )
         {
-            size = 0;
+            out_size = 0;
         }
         else
         {
-            if( SIZE_MAX / te.size_val <= size )
+            if( SIZE_MAX / te.size_val <= out_size )
                 BUG(sp, "Integer overflow calculating array size");
-            size *= te.size_val;
+            out_size *= te.size_val;
         }
         return true;
         ),

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -616,12 +616,12 @@ namespace {
                 }
             }
             } break;
-        TU_ARM(ty.m_data, Borrow, te) {
+        TU_ARM(ty.m_data, Borrow, _te) { (void)_te;
             out_path.sub_fields.push_back(0);
             Target_GetSizeOf(sp, resolve, ty, out_path.size);
             return true;
             } break;
-        TU_ARM(ty.m_data, Function, _te)
+        TU_ARM(ty.m_data, Function, _te) (void)_te;
             out_path.sub_fields.push_back(0);
             Target_GetSizeOf(sp, resolve, ty, out_path.size);
             return true;
@@ -800,7 +800,7 @@ namespace {
                 {
                     vals.push_back(v.val);
                 }
-                rv.variants = TypeRepr::VariantMode::make_Values({ 0, rv.size, ::std::move(vals) });
+                rv.variants = TypeRepr::VariantMode::make_Values({ { 0, static_cast<uint8_t>(rv.size), {} }, ::std::move(vals) });
             }
             } break;
         }

--- a/src/trans/target.hpp
+++ b/src/trans/target.hpp
@@ -54,10 +54,52 @@ struct StructRepr
     // Ordered as they would be emitted
     ::std::vector<Ent>  ents;
 };
+struct TypeRepr
+{
+    size_t  align = 0;
+    size_t  size = 0;
+
+    struct FieldPath {
+        size_t  index;
+        size_t  size;
+        ::std::vector<size_t>   sub_fields;
+    };
+    TAGGED_UNION(VariantMode, None,
+    (None, struct {
+        }),
+    // Tag is a fixed set of values in an offset.
+    (Values, struct {
+        FieldPath   field;
+        ::std::vector<uint64_t> values;
+        }),
+    // Tag is based on a range of values
+    //(Ranges, struct {
+    //    size_t  offset;
+    //    size_t  size;
+    //    ::std::vector<::std::pair<uint64_t,uint64_t>> values;
+    //    }),
+    // Tag is a boolean based on if a region is zero/non-zero
+    // Only valid for two-element enums
+    (NonZero, struct {
+        FieldPath   field;
+        uint8_t zero_variant;
+        })
+    );
+    VariantMode variants;
+
+    struct Field {
+        size_t  offset;
+        ::HIR::TypeRef  ty;
+    };
+    ::std::vector<Field>    fields;
+};
 
 extern const TargetSpec& Target_GetCurSpec();
 extern void Target_SetCfg(const ::std::string& target_name);
 extern bool Target_GetSizeOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_size);
 extern bool Target_GetAlignOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_align);
+extern bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_size, size_t& out_align);
 extern const StructRepr* Target_GetStructRepr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& struct_ty);
+
+extern const TypeRepr* Target_GetTypeRepr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty);
 

--- a/src/trans/target.hpp
+++ b/src/trans/target.hpp
@@ -103,3 +103,5 @@ extern const StructRepr* Target_GetStructRepr(const Span& sp, const StaticTraitR
 
 extern const TypeRepr* Target_GetTypeRepr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty);
 
+extern const ::HIR::TypeRef& Target_GetInnerType(const Span& sp, const StaticTraitResolve& resolve, const TypeRepr& repr, size_t idx, const ::std::vector<size_t>& sub_fields={}, size_t ofs=0);
+

--- a/tools/minicargo/Makefile
+++ b/tools/minicargo/Makefile
@@ -3,12 +3,16 @@
 # - Interprets Cargo.toml files and emits makefiles
 # - Supports overriding build script output
 #
+ifeq ($(OS),Windows_NT)
+  EXESUF ?= .exe
+endif
+EXESUF ?=
 
 V ?= @
 
 OBJDIR := .obj/
 
-BIN := ../bin/minicargo
+BIN := ../bin/minicargo$(EXESUF)
 OBJS := main.o build.o manifest.o repository.o
 OBJS += toml.o path.o debug.o
 

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -623,6 +623,11 @@ bool Builder::build_target(const PackageManifest& manifest, const PackageTarget&
             args.push_back("-C"); args.push_back(format("emit-build-command=",outfile,".sh"));
         }
     }
+    if( m_opts.emit_mmir )
+    {
+        args.push_back("-C"); args.push_back("codegen-type=monomir");
+    }
+
     args.push_back("-o"); args.push_back(outfile);
     args.push_back("-L"); args.push_back(this->get_output_dir(is_for_host).str());
     for(const auto& dir : manifest.build_script_output().rustc_link_search) {

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -5,9 +5,18 @@
  * build.cpp
  * - Logic related to invoking the compiler
  */
-#ifdef _WIN32
+#ifdef _MSC_VER
 # define _CRT_SECURE_NO_WARNINGS    // Allows use of getenv (this program doesn't set env vars)
 #endif
+
+#if defined(__MINGW32__)
+# define DISABLE_MULTITHREAD    // Mingw32 doesn't have c++11 threads
+// Mingw doesn't define putenv()
+extern "C" {
+extern int _putenv_s(const char*, const char*);
+}
+#endif
+
 #include "manifest.h"
 #include "build.h"
 #include "debug.h"
@@ -16,9 +25,11 @@
 #include <algorithm>
 #include <sstream>  // stringstream
 #include <cstdlib>  // setenv
-#include <thread>
-#include <mutex>
-#include <condition_variable>
+#ifndef DISABLE_MULTITHREAD
+# include <thread>
+# include <mutex>
+# include <condition_variable>
+#endif
 #include <climits>
 #include <cassert>
 #ifdef _WIN32
@@ -34,7 +45,12 @@
 
 #ifdef _WIN32
 # define EXESUF ".exe"
-# define HOST_TARGET "x86_64-windows-msvc"
+# ifdef _MSC_VER
+#  define HOST_TARGET "x86_64-windows-msvc"
+# elif defined(__MINGW32__)
+#  define HOST_TARGET "x86_64-windows-gnu"
+# else
+# endif
 #else
 # define EXESUF ""
 # define HOST_TARGET "x86_64-unknown-linux-gnu"
@@ -314,6 +330,7 @@ bool BuildList::build(BuildOptions opts, unsigned num_jobs)
     // Actually do the build
     if( num_jobs > 1 )
     {
+#ifndef DISABLE_MULTITHREAD
         class Semaphore
         {
             ::std::mutex    mutex;
@@ -446,7 +463,18 @@ bool BuildList::build(BuildOptions opts, unsigned num_jobs)
         {
             return false;
         }
+#else
+        while( !state.build_queue.empty() )
+        {
+            auto cur = state.get_next();
 
+            if( ! builder.build_library(*m_list[cur].package, m_list[cur].is_host) )
+            {
+                return false;
+            }
+            state.complete_package(cur, m_list);
+        }
+#endif
     }
     else if( num_jobs == 1 )
     {
@@ -514,7 +542,11 @@ Builder::Builder(BuildOptions opts):
 
     ::helpers::path minicargo_path { buf };
     minicargo_path.pop_component();
+#ifdef __MINGW32__
+    m_compiler_path = (minicargo_path / "..\\..\\bin\\mrustc.exe").normalise();
+#else
     m_compiler_path = minicargo_path / "mrustc.exe";
+#endif
 #else
     char buf[1024];
     size_t s = readlink("/proc/self/exe", buf, sizeof(buf)-1);

--- a/tools/minicargo/build.h
+++ b/tools/minicargo/build.h
@@ -12,6 +12,7 @@ struct BuildOptions
     ::helpers::path output_dir;
     ::helpers::path build_script_overrides;
     ::std::vector<::helpers::path>  lib_search_dirs;
+    bool emit_mmir = false;
     const char* target_name = nullptr;	// if null, host is used
 };
 

--- a/tools/minicargo/debug.cpp
+++ b/tools/minicargo/debug.cpp
@@ -5,6 +5,9 @@
  * debug.cpp
  * - Debugging helpers
  */
+#if defined(__MINGW32__)
+# define DISABLE_MULTITHREAD    // Mingw32 doesn't have c++11 threads
+#endif
 #include <set>
 #include <iostream>
 #include "debug.h"
@@ -13,7 +16,9 @@
 static int giIndentLevel = 0;
 static const char* gsDebugPhase = "";
 static ::std::set<::std::string> gmDisabledDebug;
+#ifndef DISABLE_MULTITHREAD
 static ::std::mutex gDebugLock;
+#endif
 
 void Debug_SetPhase(const char* phase_name)
 {
@@ -33,7 +38,9 @@ void Debug_Print(::std::function<void(::std::ostream& os)> cb)
 {
     if( !Debug_IsEnabled() )
         return ;
+#ifndef DISABLE_MULTITHREAD
     ::std::unique_lock<::std::mutex>    _lh { gDebugLock };
+#endif
 
     ::std::cout << gsDebugPhase << "- ";
     for(auto i = giIndentLevel; i --; )
@@ -45,7 +52,9 @@ void Debug_EnterScope(const char* name, dbg_cb_t cb)
 {
     if( !Debug_IsEnabled() )
         return ;
+#ifndef DISABLE_MULTITHREAD
     ::std::unique_lock<::std::mutex>    _lh { gDebugLock };
+#endif
 
     ::std::cout << gsDebugPhase << "- ";
     for(auto i = giIndentLevel; i --; )
@@ -59,7 +68,9 @@ void Debug_LeaveScope(const char* name, dbg_cb_t cb)
 {
     if( !Debug_IsEnabled() )
         return ;
+#ifndef DISABLE_MULTITHREAD
     ::std::unique_lock<::std::mutex>    _lh { gDebugLock };
+#endif
 
     ::std::cout << gsDebugPhase << "- ";
     giIndentLevel --;

--- a/tools/minicargo/main.cpp
+++ b/tools/minicargo/main.cpp
@@ -27,6 +27,9 @@ struct ProgramOptions
     // Output/build directory
     const char* output_directory = nullptr;
 
+    // Emit Monomorphised MIR instead of C
+    bool emit_mmir = false;
+
     // Target name (if null, defaults to host)
     const char* target = nullptr;
 
@@ -84,7 +87,8 @@ int main(int argc, const char* argv[])
         build_opts.build_script_overrides = ::std::move(bs_override_dir);
         build_opts.output_dir = opts.output_directory ? ::helpers::path(opts.output_directory) : ::helpers::path("output");
         build_opts.lib_search_dirs.reserve(opts.lib_search_dirs.size());
-	build_opts.target_name = opts.target;
+        build_opts.emit_mmir = opts.emit_mmir;
+        build_opts.target_name = opts.target;
         for(const auto* d : opts.lib_search_dirs)
             build_opts.lib_search_dirs.push_back( ::helpers::path(d) );
         Debug_SetPhase("Enumerate Build");
@@ -157,6 +161,25 @@ int ProgramOptions::parse(int argc, const char* argv[])
                     break;
                 }
                 this->build_jobs = ::std::strtol(argv[++i], nullptr, 10);
+                break;
+            case 'Z':
+                if( arg[2] != '\0' ) {
+                    arg = arg + 2;
+                }
+                else {
+                    if(i+1 == argc) {
+                        ::std::cerr << "Flag " << arg << " takes an argument" << ::std::endl;
+                        return 1;
+                    }
+                    arg = argv[++i];
+                }
+                if( ::std::strcmp(arg, "emit-mmir") == 0 ) {
+                    this->emit_mmir = true;
+                }
+                else {
+                    ::std::cerr << "Unknown debug option -Z " << arg << ::std::endl;
+                    return 1;
+                }
                 break;
             case 'n':
                 this->build_jobs = 0;

--- a/tools/standalone_miri/hir_sim.cpp
+++ b/tools/standalone_miri/hir_sim.cpp
@@ -12,6 +12,7 @@
 
 size_t HIR::TypeRef::get_size(size_t ofs) const
 {
+    const size_t POINTER_SIZE = 8;
     if( this->wrappers.size() <= ofs )
     {
         switch(this->inner_type)
@@ -33,7 +34,12 @@ size_t HIR::TypeRef::get_size(size_t ofs) const
             return 8;
         case RawType::U128: case RawType::I128:
             return 16;
+
+        case RawType::Function: // This should probably be invalid?
+        case RawType::USize: case RawType::ISize:
+            return POINTER_SIZE;
         }
+        throw "";
     }
     
     switch(this->wrappers[ofs].type)
@@ -48,21 +54,21 @@ size_t HIR::TypeRef::get_size(size_t ofs) const
             if( this->inner_type == RawType::Composite )
                 throw "TODO";
             else if( this->inner_type == RawType::Str )
-                return 8*2;
+                return POINTER_SIZE*2;
             else if( this->inner_type == RawType::TraitObject )
-                return 8*2;
+                return POINTER_SIZE*2;
             else
             {
-                return 8;
+                return POINTER_SIZE;
             }
         }
         else if( this->wrappers[ofs+1].type == TypeWrapper::Ty::Slice )
         {
-            return 8*2;
+            return POINTER_SIZE*2;
         }
         else
         {
-            return 8;
+            return POINTER_SIZE;
         }
     case TypeWrapper::Ty::Slice:
         throw "Invalid";

--- a/tools/standalone_miri/lex.hpp
+++ b/tools/standalone_miri/lex.hpp
@@ -13,6 +13,7 @@ enum class TokenClass
     Integer,
     Real,
     String,
+    ByteString,
 };
 
 struct Token
@@ -43,16 +44,21 @@ class Lexer
     unsigned m_cur_line;
     ::std::ifstream m_if;
     Token   m_cur;
+    bool    m_next_valid = false;
+    Token   m_next;
 public:
     Lexer(const ::std::string& path);
 
+
     const Token& next() const;
+    const Token& lookahead();
     Token consume();
     void check(TokenClass tc);
     void check(char ch);
     void check(const char* s);
-    void check_consume(char ch) { check(ch); consume(); }
-    void check_consume(const char* s) { check(s); consume(); }
+    Token check_consume(TokenClass tc) { check(tc); return consume(); }
+    Token check_consume(char ch) { check(ch); return consume(); }
+    Token check_consume(const char* s) { check(s); return consume(); }
     bool consume_if(char ch) { if(next() == ch) { consume(); return true; } return false; }
     bool consume_if(const char* s) { if(next() == s) { consume(); return true; } return false; }
 
@@ -60,4 +66,6 @@ public:
 
 private:
     void advance();
+
+    ::std::string parse_string();
 };

--- a/tools/standalone_miri/module_tree.hpp
+++ b/tools/standalone_miri/module_tree.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <set>
 
 #include "../../src/mir/mir.hpp"
 #include "hir_sim.hpp"
@@ -20,6 +21,8 @@ struct Function
 class ModuleTree
 {
     friend struct Parser;
+
+    ::std::set<::std::string>   loaded_files;
 
     ::std::map<::HIR::Path, Function>    functions;
     // Hack: Tuples are stored as `::""::<A,B,C,...>`

--- a/vsproject/build_rustc_minicargo.cmd
+++ b/vsproject/build_rustc_minicargo.cmd
@@ -6,7 +6,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 x64\Release\minicargo.exe ..\rustc-1.19.0-src\src\libtest --script-overrides ..\script-overrides\stable-1.19.0
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-x64\Release\mrustc.exe ..\rustc-1.19.0-src\src\test\run-pass\hello.rs -L output -o hello.exe
+x64\Release\mrustc.exe ..\rustc-1.19.0-src\src\test\run-pass\hello.rs -L output -o output\hello.exe
 if %errorlevel% neq 0 exit /b %errorlevel%
 hello.exe
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/vsproject/build_rustc_minicargo_mmir.cmd
+++ b/vsproject/build_rustc_minicargo_mmir.cmd
@@ -1,0 +1,12 @@
+@echo off
+x64\Release\minicargo.exe ..\rustc-1.19.0-src\src\libstd --script-overrides ..\script-overrides\stable-1.19.0 --output-dir output_mmir -Z emit-mmir
+if %errorlevel% neq 0 exit /b %errorlevel%
+x64\Release\minicargo.exe ..\rustc-1.19.0-src\src\libpanic_unwind --script-overrides ..\script-overrides\stable-1.19.0 --output-dir output_mmir -Z emit-mmir
+if %errorlevel% neq 0 exit /b %errorlevel%
+x64\Release\minicargo.exe ..\rustc-1.19.0-src\src\libtest --script-overrides ..\script-overrides\stable-1.19.0 --output-dir output_mmir -Z emit-mmir
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+x64\Release\mrustc.exe ..\rustc-1.19.0-src\src\test\run-pass\hello.rs -L output_mmir -o output_mmir\hello.exe -C codegen-type=monomir
+if %errorlevel% neq 0 exit /b %errorlevel%
+x64\Release\standalone_miri.exe output_mmir\hello.exe.mir
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/vsproject/mrustc.vcxproj
+++ b/vsproject/mrustc.vcxproj
@@ -244,6 +244,7 @@
     <ClCompile Include="..\src\trans\codegen.cpp" />
     <ClCompile Include="..\src\trans\codegen_c.cpp" />
     <ClCompile Include="..\src\trans\codegen_c_structured.cpp" />
+    <ClCompile Include="..\src\trans\codegen_mmir.cpp" />
     <ClCompile Include="..\src\trans\enumerate.cpp" />
     <ClCompile Include="..\src\trans\mangling.cpp" />
     <ClCompile Include="..\src\trans\monomorphise.cpp" />

--- a/vsproject/mrustc.vcxproj.filters
+++ b/vsproject/mrustc.vcxproj.filters
@@ -389,6 +389,9 @@
     <ClCompile Include="..\src\expand\proc_macro.cpp">
       <Filter>Source Files\expand</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\trans\codegen_mmir.cpp">
+      <Filter>Source Files\trans</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\common.hpp">


### PR DESCRIPTION
Contains the structure required for `standalone_miri` to work. This mainly replaces the slap-dash struct size calculation and codegen_c's nonzero enum optimisation with a more generalised approach.

Still has issues with warnings in the generated C (likely related to handling of negatives in enum variants).

Waiting on a full integration test pass before merge.,