### PR TITLE
Add OpenBSD support.

### DIFF
--- a/src/expand/proc_macro.cpp
+++ b/src/expand/proc_macro.cpp
@@ -24,6 +24,10 @@
 # include <sys/wait.h>
 #endif
 
+#ifdef __OpenBSD__
+extern char **environ;
+#endif
+
 #define NEWNODE(_ty, ...)   ::AST::ExprNodeP(new ::AST::ExprNode##_ty(__VA_ARGS__))
 
 class Decorator_ProcMacroDerive:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,18 @@
 # else
 #  define DEFAULT_TARGET_NAME "i586-windows-gnu"
 # endif
+#elif defined(__OpenBSD__)
+# if defined(__amd64__)
+#  define DEFAULT_TARGET_NAME "x86_64-unknown-openbsd"
+# elif defined(__aarch64__)
+#  define DEFAULT_TARGET_NAME "arm64-unknown-openbsd"
+# elif defined(__arm__)
+#  define DEFAULT_TARGET_NAME "arm-unknown-openbsd"
+# elif defined(__i386__)
+#  define DEFAULT_TARGET_NAME "i686-unknown-openbsd"
+# else
+#  error "Unable to detect a suitable default target (OpenBSD)"
+# endif
 #else
 # error "Unable to detect a suitable default target"
 #endif

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -94,6 +94,27 @@ namespace
                 ARCH_X86_64
                 };
         }
+        else if(target_name == "i686-unknown-openbsd")
+        {
+            return TargetSpec {
+                "unix", "openbsd", "gnu", CodegenMode::Gnu11, "i686-unknown-openbsd",
+                ARCH_X86
+                };
+        }
+        else if(target_name == "x86_64-unknown-openbsd")
+        {
+            return TargetSpec {
+                "unix", "openbsd", "gnu", CodegenMode::Gnu11, "x86_64-unknown-openbsd",
+                ARCH_X86_64
+                };
+        }
+        else if(target_name == "arm-unknown-openbsd")
+        {
+            return TargetSpec {
+                "unix", "openbsd", "gnu", CodegenMode::Gnu11, "arm-unknown-openbsd",
+                ARCH_ARM32
+                };
+        }
         else
         {
             ::std::cerr << "Unknown target name '" << target_name << "'" << ::std::endl;
@@ -123,6 +144,13 @@ void Target_SetCfg(const ::std::string& target_name)
     {
         Cfg_SetFlag("linux");
         Cfg_SetValue("target_vendor", "gnu");
+    }
+    Cfg_SetValue("target_env", g_target.m_env_name);
+
+    if( g_target.m_os_name == "openbsd" )
+    {
+        Cfg_SetFlag("openbsd");
+        Cfg_SetValue("target_vendor", "unknown");
     }
     Cfg_SetValue("target_env", g_target.m_env_name);
 


### PR DESCRIPTION
Hi --

This pull request allows a working mrustc to build on OpenBSD (at least, OpenBSD/amd64).
Not included in this are tweaks to the build system to get mrustc to do its build-checking with rust, because that is quite invasive and I'm still unsure about the best way to proceed with upstreaming that.