### PR TITLE
Remove quotes from LLVM_TARGETS declaration in minicargo.mk

### DIFF
--- a/minicargo.mk
+++ b/minicargo.mk
@@ -35,7 +35,7 @@ endif
 
 LLVM_CONFIG := $(RUSTCSRC)build/bin/llvm-config
 RUSTC_TARGET ?= x86_64-unknown-linux-gnu
-LLVM_TARGETS ?= "X86;ARM;AArch64" #;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX
+LLVM_TARGETS ?= X86;ARM;AArch64#;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX
 OVERRIDE_DIR := script-overrides/$(RUSTC_CHANNEL)-$(RUSTC_VERSION)$(OVERRIDE_SUFFIX)/
 
 .PHONY: bin/mrustc tools/bin/minicargo


### PR DESCRIPTION
This is wrapped again and becomes unquoted when used in LLVM_CMAKE_OPTS,
 breaking the build:

[...]
cd rustc-1.19.0-src/build && cmake -D LLVM_TARGET_ARCH=x86_64 -D LLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-linux-gnu
-D LLVM_TARGETS_TO_BUILD=""X86;ARM;AArch64" -D " -D LLVM_ENABLE_ASSERTIONS=OFF -D LLVM_INCLUDE_EXAMPLES=OFF -D
LLVM_INCLUDE_TESTS=OFF -D LLVM_INCLUDE_DOCS=OFF -D LLVM_ENABLE_ZLIB=OFF -D LLVM_ENABLE_TERMINFO=OFF -D
LLVM_ENABLE_LIBEDIT=OFF -D WITH_POLLY=OFF -D CMAKE_CXX_COMPILER="g++" -D CMAKE_C_COMPILER="gcc" -D
CMAKE_BUILD_TYPE=RelWithDebInfo ../src/llvm
CMake Error: The source directory "/home/aclemons/workspace/mrustc/rustc-1.19.0-src/build/LLVM_TARGETS_TO_BUILD=X86"
does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
/bin/sh: ARM: command not found
/bin/sh: AArch64 -D : command not found
minicargo.mk:110: recipe for target 'rustc-1.19.0-src/build/Makefile' failed
make: *** [rustc-1.19.0-src/build/Makefile] Error 127