### PR TITLE
Trans - Add initial support for m68k

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -34,6 +34,11 @@ const TargetArch ARCH_ARM32 = {
     32, false,
     { /*atomic(u8)=*/true, false, true, false,  true }
 };
+const TargetArch ARCH_M68K = {
+    "m68k",
+    32, true,
+    { /*atomic(u8)=*/true, false, true, false,  true }
+};
 TargetSpec  g_target;
 
 
@@ -107,6 +112,10 @@ namespace
                         else if( key_val.value.as_string() == ARCH_X86_64.m_name )
                         {
                             rv.m_arch = ARCH_X86_64;
+                        }
+                        else if( key_val.value.as_string() == ARCH_M68K.m_name )
+                        {
+                            rv.m_arch = ARCH_M68K;
                         }
                         else
                         {
@@ -330,6 +339,13 @@ namespace
             return TargetSpec {
                 "unix", "linux", "gnu", {CodegenMode::Gnu11, "aarch64-linux-gnu", BACKEND_C_OPTS_GNU},
                 ARCH_ARM64
+                };
+        }
+        else if(target_name == "m68k-linux-gnu")
+        {
+            return TargetSpec {
+                "unix", "linux", "gnu", {CodegenMode::Gnu11, "m68k-linux-gnu", BACKEND_C_OPTS_GNU},
+                ARCH_M68K
                 };
         }
         else if(target_name == "i586-windows-gnu")

--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -24,6 +24,8 @@
 #  define DEFAULT_TARGET_NAME "arm-linux-gnu"
 # elif defined(__i386__)
 #  define DEFAULT_TARGET_NAME "i586-linux-gnu"
+# elif defined(__m68k__)
+#  define DEFAULT_TARGET_NAME "m68k-linux-gnu"
 # else
 #  warning "Unable to detect a suitable default target (linux-gnu)"
 # endif


### PR DESCRIPTION
This adds initial support for m68k, currently on Linux only. With these changes, I am able to build mrustc on qemu-m68k.

There are some alignment issues that need to be sorted out due to the fact that the natural alignment on m68k is 16 bits and not 32 bits, despite being a 32-bit architecture. I will address those issues in future patches.