### PR TITLE
Mark destructors on base classes as virtual

### DIFF
--- a/src/ast/expr.hpp
+++ b/src/ast/expr.hpp
@@ -623,6 +623,7 @@ struct ExprNode_UniOp:
 class NodeVisitor
 {
 public:
+    virtual ~NodeVisitor() = default;
     inline void visit(const unique_ptr<ExprNode>& cnode) {
         if(cnode.get())
             cnode->visit(*this);

--- a/src/expand/derive.cpp
+++ b/src/expand/derive.cpp
@@ -72,6 +72,7 @@ struct DeriveOpts
 /// Interface for derive handlers
 struct Deriver
 {
+    virtual ~Deriver() = default;
     virtual const char* trait_name() const = 0;
     virtual AST::Impl handle_item(Span sp, const DeriveOpts& opts, const AST::GenericParams& p, const TypeRef& type, const AST::Struct& str) const = 0;
     virtual AST::Impl handle_item(Span sp, const DeriveOpts& opts, const AST::GenericParams& p, const TypeRef& type, const AST::Enum& enm) const = 0;

--- a/src/hir/expr.hpp
+++ b/src/hir/expr.hpp
@@ -815,6 +815,7 @@ struct ExprNode_Closure:
 class ExprVisitor
 {
 public:
+    virtual ~ExprVisitor() = default;
     virtual void visit_node_ptr(::std::unique_ptr<ExprNode>& node_ptr);
     virtual void visit_node(ExprNode& node);
     #define NV(nt)  virtual void visit(nt& n) = 0;

--- a/src/hir_typeck/expr_cs.cpp
+++ b/src/hir_typeck/expr_cs.cpp
@@ -25,6 +25,7 @@ struct Context
     class Revisitor
     {
     public:
+        virtual ~Revisitor() = default;
         virtual void fmt(::std::ostream& os) const = 0;
         virtual bool revisit(Context& context) = 0;
     };

--- a/src/include/synext_decorator.hpp
+++ b/src/include/synext_decorator.hpp
@@ -45,6 +45,7 @@ class ExpandDecorator
 {
     void unexpected(const Span& sp, const AST::Attribute& mi, const char* loc_str) const;
 public:
+    virtual ~ExpandDecorator() = default;
     virtual AttrStage   stage() const = 0;
 
     virtual void    handle(const Span& sp, const AST::Attribute& mi, AST::Crate& crate) const { unexpected(sp, mi, "crate"); }

--- a/src/include/synext_macro.hpp
+++ b/src/include/synext_macro.hpp
@@ -27,6 +27,7 @@ class TokenStream;
 class ExpandProcMacro
 {
 public:
+    virtual ~ExpandProcMacro() = default;
     virtual ::std::unique_ptr<TokenStream>  expand(const Span& sp, const AST::Crate& crate, const ::std::string& ident, const TokenTree& tt, AST::Module& mod) = 0;
 };
 


### PR DESCRIPTION
In many situations, objects are deleted by deleting a pointer to their base class. In the previous code, these destructors were non-virtual. This violates a C++ rule (so it's undefined behavior), and on some platforms (such as Clang with -fsized-deallocation), this violation is detected and causes mrustc to abort.

The fix is simple; mark the relevant destructors as virtual.
