### PR TITLE
Fix a few bugs (in non-debug config), clean up warnings

### DIFF
--- a/src/hir_expand/annotate_value_usage.cpp
+++ b/src/hir_expand/annotate_value_usage.cpp
@@ -61,7 +61,7 @@ namespace {
             root_ptr->m_usage = this->get_usage();
             auto expected_size = m_usage.size();
             root_ptr->visit( *this );
-            assert( m_usage.size() == expected_size );
+            assert_or_ignore( m_usage.size() == expected_size );
         }
         void visit_node_ptr(::HIR::ExprNodeP& node_ptr) override
         {
@@ -75,7 +75,7 @@ namespace {
 
             auto expected_size = m_usage.size();
             node_ptr->visit( *this );
-            assert( m_usage.size() == expected_size );
+            assert_or_ignore( m_usage.size() == expected_size );
         }
 
         void visit(::HIR::ExprNode_Block& node) override

--- a/src/hir_typeck/expr_cs.cpp
+++ b/src/hir_typeck/expr_cs.cpp
@@ -1782,7 +1782,7 @@ namespace {
                         this->context.equate_types(node.span(), t, *e.type);
                     }
                     for(const auto& ty : impl_params.m_types)
-                        assert( !( ty.m_data.is_Infer() && ty.m_data.as_Infer().index == ~0u) );
+                        assert_or_ignore( !( ty.m_data.is_Infer() && ty.m_data.as_Infer().index == ~0u) );
                 }
 
 
@@ -2361,7 +2361,7 @@ namespace {
                 const auto& lang_InPlace = this->context.m_crate.get_lang_item_path(sp, "in_place_trait");
                 // - Bound P: Placer<D>
                 this->context.equate_types_assoc(sp, {}, lang_Placer, ::make_vec1(data_ty.clone()), placer_ty, "");
-                // - 
+                // -
                 auto place_ty = ::HIR::TypeRef( ::HIR::Path(placer_ty.clone(), ::HIR::GenericPath(lang_Placer, ::HIR::PathParams(data_ty.clone())), "Place") );
                 this->context.equate_types_assoc(sp, node.m_res_type, lang_InPlace, ::make_vec1(data_ty.clone()), place_ty, "Owner");
                 break; }
@@ -3836,7 +3836,7 @@ void Context::add_binding(const Span& sp, ::HIR::Pattern& pat, const ::HIR::Type
     (StructValue,
         this->add_ivars_params( e.path.m_params );
         const auto& str = *e.binding;
-        assert( str.m_data.is_Unit() );
+        assert_or_ignore( str.m_data.is_Unit() );
         this->equate_types( sp, type, ::HIR::TypeRef::new_path(e.path.clone(), ::HIR::TypeRef::TypePathBinding(e.binding)) );
         ),
     (StructTuple,
@@ -4943,7 +4943,7 @@ namespace {
                 return CoerceResult::Equality;
             }
             const auto* dep = &dst.m_data.as_Pointer();
-        
+
             // If using `*mut T` where `*const T` is expected - add cast
             if( dep->type == ::HIR::BorrowType::Shared && se.type == ::HIR::BorrowType::Unique )
             {
@@ -4983,7 +4983,7 @@ namespace {
             {
                 // Add cast to the pointer (if valid strength reduction)
                 // Call unsizing code on casted value
-                
+
                 // Borrows can coerce to pointers while reducing in strength
                 // - Shared < Unique. If the destination is not weaker or equal to the source, it's an error
                 if( !(dep->type <= se.type) ) {
@@ -6005,7 +6005,7 @@ namespace {
             H::dedup_type_list_with(types_to, [&](const auto& l, const auto& r) {
                     return context.m_ivars.types_equal(l, r) ? DedupKeep::Left : DedupKeep::Both;
                     });
-            
+
             // If there is a common type in both lists, use it
             for(const auto& t1 : types_from)
             {

--- a/src/include/debug.hpp
+++ b/src/include/debug.hpp
@@ -80,4 +80,34 @@ struct FmtLambda
 #define FMT_CB(os, ...)  ::FmtLambda( [&](auto& os) { __VA_ARGS__; } )
 #define FMT_CB_S(...)  ::FmtLambda( [&](auto& _os) { _os << __VA_ARGS__; } )
 
+// This function should be used in situations where you want to unconditionally
+// run some code (probably because it has side effects), and in debug builds,
+// you want to check the result of the code. In non-debug builds, this function
+// will still evaluate its arguments (which is what we want), but will ignore
+// the results.
+//
+// Don't convert this to a preprocessor macro. That would defeat the whole
+// purpose of this function.
+static inline void assert_or_ignore(bool value) {
+    assert(value);
+}
 
+// Similar to assert_or_ignore(), this function allows you to compute a value
+// and then ignore its results. For expressions that have side-effects, the
+// side-effects will still occur. For expressions that don't have side-effects
+// (such as "a * 2"), the optimizer will remove all of the parts of the
+// expression that are obviously side-effect free (dead-code elimination).
+//
+// This function is intended to be used in situations where we compute a value,
+// store it in a local variable, and then use assert() to check things related
+// to that value, so that we can avoid "unused value" warnings on non-debug
+// builds. Example:
+//
+//     size_t foo = compute_some_size();
+//     assert(foo > 0);         // it's big
+//     assert(foo % 4 == 0);    // it's aligned
+//     ignore(foo);             // no warning on debug builds
+//
+// Don't convert this to a preprocessor macro. That would defeat the whole
+// purpose of this function.
+static inline void ignore(bool value) {}

--- a/src/mir/helpers.cpp
+++ b/src/mir/helpers.cpp
@@ -577,8 +577,8 @@ namespace
         {
             size_t  limit = block_offsets[bb+1] - block_offsets[bb] - 1;
             DEBUG("bb" << bb << " : " << first_stmt << "--" << last_stmt);
-            assert(first_stmt <= limit);
-            assert(last_stmt <= limit);
+            assert_or_ignore(first_stmt <= limit);
+            assert_or_ignore(last_stmt <= limit);
             for(size_t stmt = first_stmt; stmt <= last_stmt; stmt++)
             {
                 stmt_bitmap[block_offsets[bb] + stmt] = true;
@@ -941,7 +941,7 @@ void MIR_Helper_GetLifetimes_DetermineValueLifetime(
                     }
                     ),
                 (Asm,
-                    // 
+                    //
                     for(const auto& e : se.outputs)
                     {
                         if(e.second == m_lv) {

--- a/src/mir/mir_builder.cpp
+++ b/src/mir/mir_builder.cpp
@@ -122,7 +122,7 @@ void MirBuilder::define_variable(unsigned int idx)
             if( !e.is_temporary )
             {
                 auto it = ::std::find(e.slots.begin(), e.slots.end(), idx);
-                assert(it == e.slots.end());
+                assert_or_ignore(it == e.slots.end());
                 e.slots.push_back( idx );
                 return ;
             }

--- a/src/parse/expr.cpp
+++ b/src/parse/expr.cpp
@@ -168,7 +168,7 @@ ExprNodeP Parse_ExprBlockLine_WithItems(TokenStream& lex, ::std::shared_ptr<AST:
         else {
         }
         return rv;
-        } break;
+        }
     }
 }
 

--- a/src/parse/pattern.cpp
+++ b/src/parse/pattern.cpp
@@ -263,7 +263,7 @@ AST::Pattern Parse_PatternReal1(TokenStream& lex, bool is_refutable)
         else {
             TODO(lex.point_span(), "Convert :expr into a pattern value - " << *e);
         }
-        } break;
+        }
 
     case TOK_PAREN_OPEN:
         return AST::Pattern( AST::Pattern::TagTuple(), lex.end_span(mv$(ps)), Parse_PatternTuple(lex, is_refutable) );

--- a/src/resolve/index.cpp
+++ b/src/resolve/index.cpp
@@ -86,7 +86,7 @@ void _add_item(const Span& sp, AST::Module& mod, IndexName location, const ::std
             DEBUG("### Add " << location << " item '" << name << "': " << ir);
         }
         auto rec = list.insert(::std::make_pair(name, ::AST::Module::IndexEnt { is_pub, was_import, mv$(ir) } ));
-        assert(rec.second);
+        assert_or_ignore(rec.second);
     }
 }
 void _add_item_type(const Span& sp, AST::Module& mod, const ::std::string& name, bool is_pub, ::AST::Path ir, bool error_on_collision=true)

--- a/tools/common/debug.h
+++ b/tools/common/debug.h
@@ -73,4 +73,3 @@ template<typename T>
     }
     return os;
 }
-

--- a/tools/common/toml.h
+++ b/tools/common/toml.h
@@ -26,9 +26,6 @@ class TomlFile
     /// Path suffix of the current composite (none if empty)
     ::std::vector<::std::string>    m_current_composite;
 
-    /// Index of the next array field (if zero, not parsing an array)
-    unsigned int m_next_array_index;
-
     /// Next indexes if top-level defined arrays (e.g. `[[foo]]`)
     ::std::unordered_map<::std::string,unsigned>    m_array_counts;
 
@@ -87,7 +84,7 @@ struct TomlValue
     };
 
     Type m_type;
-    uint64_t    m_int_value;
+    uint64_t    m_int_value = 0;
     ::std::string   m_str_value;
     ::std::vector<TomlValue>    m_sub_values;
 


### PR DESCRIPTION
In several places, we called functions and relied on their
side-effects, within an assert() call. This means that when
building for non-debug configurations, the side-effect
expressions did not run, and so they never computed the
values that we needed (stuff we needed even beyond the
assert() call). This fixes them by adding an assert_or_ignore()
function, an ignore() function, and by moving some repeated code
to a function in codegen_mmir.cpp.

This also fixes several warnings. GCC and Clang do control-flow
analysis slightly differently. In some situations, GCC thinks that
a particular point in control-flow is reachable, while Clang thinks
that the same point is not reachable. This causes the analysis of
whether a function always returns a value to fail (erroneously).
This commit fixes this by removing a few "break;" statements that
were confusing GCC.