### PR TITLE
Trans - Fix alignment values for m68k

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -42,7 +42,7 @@ const TargetArch ARCH_M68K = {
     "m68k",
     32, true,
     { /*atomic(u8)=*/true, false, true, false,  true },
-    TargetArch::Alignments(2, 4, 8, 16, 4, 8, 4) // TODO: Does m68k have lower alignments?
+    TargetArch::Alignments(2, 2, 2, 2, 2, 2, 2)
 };
 TargetSpec  g_target;
 


### PR DESCRIPTION
For historic reasons, m68k uses 16-bit alignment for all types it supports.

The output of the test program from #83 is:

m68k (gcc 8.2.0):

```
Type         Alignment/Bytes  Size/Bytes
int8_t       1                1
int16_t      2                2
int32_t      2                4
int64_t      2                8
__int128     not supported
uint8_t      1                1
uint16_t     2                2
uint32_t     2                4
uint64_t     2                8
float        2                4
double       2                8
long double  2                12
size_t       2                4
off_t        2                4
void*        2                4
```