### PR TITLE
Allow square brackets in macro definitions

### DIFF
--- a/samples/test/issue-mrustc-103.rs
+++ b/samples/test/issue-mrustc-103.rs
@@ -1,0 +1,9 @@
+macro_rules! pat {
+  [$a:expr;$b:expr] => (
+    println!("{} {}", $a, $b);
+  )
+}
+fn main() {
+        pat![4;5];
+}
+

--- a/src/macro_rules/parse.cpp
+++ b/src/macro_rules/parse.cpp
@@ -254,6 +254,7 @@ MacroRule Parse_MacroRules_Var(TokenStream& lex)
     {
     case TOK_BRACE_OPEN:    close = TOK_BRACE_CLOSE;    break;
     case TOK_PAREN_OPEN:    close = TOK_PAREN_CLOSE;    break;
+    case TOK_SQUARE_OPEN:   close = TOK_SQUARE_CLOSE;   break;
     default:
         throw ParseError::Unexpected(lex, tok);
     }


### PR DESCRIPTION
Fixes #103