### PR TITLE
Add support for crates renaming

### DIFF
--- a/tools/minicargo/manifest.cpp
+++ b/tools/minicargo/manifest.cpp
@@ -588,7 +588,7 @@ void PackageRef::fill_from_kv(bool was_added, const TomlKeyValue& key_val, size_
         else
         {
             // TODO: Error
-            throw ::std::runtime_error(::format("ERROR: Unkown depencency attribute `", attr, "` on dependency `", this->m_name, "`"));
+            throw ::std::runtime_error(::format("ERROR: Unkown dependency attribute `", attr, "` on dependency `", this->m_name, "`"));
         }
     }
 }

--- a/tools/minicargo/manifest.cpp
+++ b/tools/minicargo/manifest.cpp
@@ -580,6 +580,11 @@ void PackageRef::fill_from_kv(bool was_added, const TomlKeyValue& key_val, size_
                 this->m_features.push_back( sv.as_string() );
             }
         }
+        else if ( attr == "package" )
+        {
+            assert(key_val.path.size() == base_idx+1);
+            this->m_name = key_val.value.as_string();
+        }
         else
         {
             // TODO: Error


### PR DESCRIPTION
So I started by checking if mrustc is vulnerable to the cargo advisory[1].
from this line it seems like it's not: https://github.com/thepowersgang/mrustc/blob/ebd8edeb4f1861943cc82d310564b1f592e63272/tools/minicargo/manifest.cpp#L705

Anyway I decided to just add support for renaming. tested it locally and it works correctly.
not sure where/how to add tests here for minicargo.

[1] https://blog.rust-lang.org/2019/09/30/Security-advisory-for-cargo.html