### PR TITLE
Expand - Fix for macro format args for strings including null literals

### DIFF
--- a/src/expand/format_args.cpp
+++ b/src/expand/format_args.cpp
@@ -200,7 +200,8 @@ namespace {
         ::std::string   cur_literal;
 
         const char* s = format_string.c_str();
-        for( ; *s; s ++)
+        const char* const s_end = s + format_string.length();
+        for( ; s < s_end; s ++)
         {
             if( *s != '{' )
             {
@@ -229,7 +230,7 @@ namespace {
 
                 // Debugging: A view of the formatting fragment
                 const char* s2 = s;
-                while(*s2 && *s2 != '}')
+                while(s2 < s_end && *s2 != '}')
                     s2 ++;
                 auto fmt_frag_str = string_view { s, s2 };
 


### PR DESCRIPTION
Formatted strings that included null literals dropped any characters past (and including) the null literal.

For example,
`println!("Hello\0World");`
prints "Hello", when it should print "Hello World" (with a \0 separating the words).

This change fixes the bug by using the length of the string rather than detecting a null terminator when processing.

This bug caused mrustc-compiled cargo to randomly crash about 20% of the time with the error "failed to create jobserver" on Windows because it caused a non-null terminated string to be passed for the name of the semaphore.