### PR TITLE
minicargo - Allow build.rs to specify dependencies with '-'

### DIFF
--- a/tools/minicargo/manifest.cpp
+++ b/tools/minicargo/manifest.cpp
@@ -890,7 +890,7 @@ void PackageManifest::load_build_script(const ::std::string& path)
             }
             // - Ignore
             else {
-                if( this->m_links != "" && line.find_first_of('-') == ::std::string::npos ) {
+                if( this->m_links != "" && std::find(key.begin(), key.end(), '-') == key.end() ) {
                     ::std::string   varname;
                     varname += "DEP_";
                     for(auto c : this->m_links)


### PR DESCRIPTION
Build dependency lines containing a `-` character were ignored. This caused breaks when the dependency line contained a path to a directory with a `-` in it (such as `output-1.29.0`).

This change resolves the issue by removing the check for `-`. Removing the check didn't appear to break anything, so I'm unsure of the intent of the check.