### PR TITLE
codegen_c - fixes for MSVC atomics

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -476,15 +476,55 @@ namespace {
                     << "\treturn __builtin_add_overflow_i" << Target_GetCurSpec().m_arch.m_pointer_bits << "(a, b, out);\n"
                     << "}\n"
                     << "static inline uint64_t __builtin_bswap64(uint64_t v) { return _byteswap_uint64(v); }\n"
-                    << "static inline uint8_t InterlockedCompareExchange8(volatile uint8_t* v, uint8_t n, uint8_t e){ return _InterlockedCompareExchange8(v, n, e); }\n"
-                    << "static inline uint8_t InterlockedCompareExchangeNoFence8(volatile uint8_t* v, uint8_t n, uint8_t e){ return InterlockedCompareExchange8(v, n, e); }\n"
-                    << "static inline uint8_t InterlockedCompareExchangeAcquire8(volatile uint8_t* v, uint8_t n, uint8_t e){ return InterlockedCompareExchange8(v, n, e); }\n"
-                    << "static inline uint8_t InterlockedCompareExchangeRelease8(volatile uint8_t* v, uint8_t n, uint8_t e){ return InterlockedCompareExchange8(v, n, e); }\n"
-                    //<< "static inline uint8_t InterlockedExchange8(volatile uint8_t* v, uint8_t n){ return _InterlockedExchange8((volatile char*)v, (char)n); }\n"
-                    << "static inline uint8_t InterlockedExchangeNoFence8(volatile uint8_t* v, uint8_t n){ return InterlockedExchange8(v, n); }\n"
-                    << "static inline uint8_t InterlockedExchangeAcquire8(volatile uint8_t* v, uint8_t n){ return InterlockedExchange8(v, n); }\n"
-                    << "static inline uint8_t InterlockedExchangeRelease8(volatile uint8_t* v, uint8_t n){ return InterlockedExchange8(v, n); }\n"
-                    << "static inline uint8_t InterlockedCompareExchange32(volatile uint32_t* v, uint32_t n, uint32_t e){ return InterlockedCompareExchange(v, n, e); }\n"
+                    << "#define InterlockedCompareExchange8Acquire _InterlockedCompareExchange8\n"
+                    << "#define InterlockedCompareExchange8Release _InterlockedCompareExchange8\n"
+                    << "#define InterlockedCompareExchange8NoFence _InterlockedCompareExchange8\n"
+                    << "#define InterlockedCompareExchange8 _InterlockedCompareExchange8\n"
+                    << "#define InterlockedCompareExchange16Acquire InterlockedCompareExchangeAcquire16\n"
+                    << "#define InterlockedCompareExchange16Release InterlockedCompareExchangeRelease16\n"
+                    << "#define InterlockedCompareExchange16NoFence InterlockedCompareExchangeNoFence16\n"
+                    << "#define InterlockedCompareExchange64Acquire InterlockedCompareExchangeAcquire64\n"
+                    << "#define InterlockedCompareExchange32 InterlockedCompareExchange\n"
+                    << "#define InterlockedCompareExchange64Release InterlockedCompareExchangeRelease64\n"
+                    << "#define InterlockedCompareExchange64NoFence InterlockedCompareExchangeNoFence64\n"
+                    << "#define InterlockedExchangeAdd8Acquire InterlockedExchangeAdd8\n"
+                    << "#define InterlockedExchangeAdd8Release InterlockedExchangeAdd8\n"
+                    << "#define InterlockedExchangeAdd8NoFence InterlockedExchangeAdd8\n"
+                    << "#define InterlockedExchangeAdd16Acquire _InterlockedExchangeAdd16\n"
+                    << "#define InterlockedExchangeAdd16Release _InterlockedExchangeAdd16\n"
+                    << "#define InterlockedExchangeAdd16NoFence _InterlockedExchangeAdd16\n"
+                    << "#define InterlockedExchangeAdd16 _InterlockedExchangeAdd16\n"
+                    << "#define InterlockedExchangeAdd64Acquire InterlockedExchangeAddAcquire64\n"
+                    << "#define InterlockedExchangeAdd64Release InterlockedExchangeAddRelease64\n"
+                    << "#define InterlockedExchangeAdd64NoFence InterlockedExchangeAddNoFence64\n"
+                    << "#define InterlockedExchange8Acquire InterlockedExchange8\n"
+                    << "#define InterlockedExchange8Release InterlockedExchange8\n"
+                    << "#define InterlockedExchange8NoFence InterlockedExchange8\n"
+                    << "#define InterlockedExchange16Acquire InterlockedExchange16\n"
+                    << "#define InterlockedExchange16Release InterlockedExchange16\n"
+                    << "#define InterlockedExchange16NoFence InterlockedExchange16\n"
+                    << "#define InterlockedExchangeRelease InterlockedExchange\n"
+                    << "#define InterlockedExchange64Acquire InterlockedExchangeAcquire64\n"
+                    << "#define InterlockedExchange64Release InterlockedExchange64\n"
+                    << "#define InterlockedExchange64NoFence InterlockedExchangeNoFence64\n"
+                    << "#define InterlockedAnd8Acquire InterlockedAnd8\n"
+                    << "#define InterlockedAnd8Release InterlockedAnd8\n"
+                    << "#define InterlockedAnd8NoFence InterlockedAnd8\n"
+                    << "#define InterlockedAnd16Acquire InterlockedAnd16\n"
+                    << "#define InterlockedAnd16Release InterlockedAnd16\n"
+                    << "#define InterlockedAnd16NoFence InterlockedAnd16\n"
+                    << "#define InterlockedOr8Acquire InterlockedOr8\n"
+                    << "#define InterlockedOr8Release InterlockedOr8\n"
+                    << "#define InterlockedOr8NoFence InterlockedOr8\n"
+                    << "#define InterlockedOr16Acquire InterlockedOr16\n"
+                    << "#define InterlockedOr16Release InterlockedOr16\n"
+                    << "#define InterlockedOr16NoFence InterlockedOr16\n"
+                    << "#define InterlockedXor8Acquire InterlockedXor8\n"
+                    << "#define InterlockedXor8Release InterlockedXor8\n"
+                    << "#define InterlockedXor8NoFence InterlockedXor8\n"
+                    << "#define InterlockedXor16Acquire InterlockedXor16\n"
+                    << "#define InterlockedXor16Release InterlockedXor16\n"
+                    << "#define InterlockedXor16NoFence InterlockedXor16\n"
                     ;
                 // Atomic hackery
                 for(int sz = 8; sz <= 64; sz *= 2)
@@ -4181,7 +4221,7 @@ namespace {
             }
             else if( matches_template("xacquire; lock; cmpxchgq $2, $1", /*input=*/{"r", "{rax}"}, /*output=*/{"={rax}", "+*m"}) )
             {
-                m_of << indent << "InterlockedCompareExchange64Acquire(";
+                m_of << indent << "InterlockedCompareExchangeAcquire64(";
                 emit_lvalue(e.outputs[1].second); m_of << ",";
                 emit_lvalue(e.inputs[0].second); m_of << ",";
                 emit_lvalue(e.inputs[1].second);
@@ -4190,7 +4230,7 @@ namespace {
             }
             else if( matches_template("xrelease; lock; cmpxchgq $2, $1", /*input=*/{"r", "{rax}"}, /*output=*/{"={rax}", "+*m"}) )
             {
-                m_of << indent << "InterlockedCompareExchange64Release(";
+                m_of << indent << "InterlockedCompareExchangeRelease64(";
                 emit_lvalue(e.outputs[1].second); m_of << ",";
                 emit_lvalue(e.inputs[0].second); m_of << ",";
                 emit_lvalue(e.inputs[1].second);
@@ -4390,41 +4430,39 @@ namespace {
                         MIR_BUG(mir_res, "Unknown primitive for getting size- " << ty);
                     }
                 };
-            auto emit_msvc_atomic_op = [&](const char* name, Ordering ordering, bool is_before_size=false) {
-                const char* o_before = is_before_size ? get_atomic_suffix_msvc(ordering) : "";
-                const char* o_after  = is_before_size ? "" : get_atomic_suffix_msvc(ordering);
+            auto emit_msvc_atomic_op = [&](const char* name, Ordering ordering) {
+                m_of << name;
                 switch (params.m_types.at(0).m_data.as_Primitive())
                 {
                 case ::HIR::CoreType::U8:
                 case ::HIR::CoreType::I8:
-                    m_of << name << o_before << "8" << o_after << "(";
+                    m_of << "8";
                     break;
                 case ::HIR::CoreType::U16:
                 case ::HIR::CoreType::I16:
-                    m_of << name << o_before << "16" << o_after << "(";
+                    m_of << "16";
                     break;
                 case ::HIR::CoreType::U32:
                 case ::HIR::CoreType::I32:
-                    m_of << name << o_before << o_after << "(";
                     break;
                 case ::HIR::CoreType::U64:
                 case ::HIR::CoreType::I64:
-                    m_of << name << o_before << "64" << o_after << "(";
+                    m_of << "64";
                     break;
                 case ::HIR::CoreType::Usize:
                 case ::HIR::CoreType::Isize:
-                    m_of << name << o_before;
                     if( Target_GetCurSpec().m_arch.m_pointer_bits == 64 )
                         m_of << "64";
                     else if( Target_GetCurSpec().m_arch.m_pointer_bits == 32 )
                         m_of << "";
                     else
                         MIR_TODO(mir_res, "Handle non 32/64 bit pointer types");
-                    m_of << o_after << "(";
                     break;
                 default:
                     MIR_BUG(mir_res, "Unsupported atomic type - " << params.m_types.at(0));
                 }
+                m_of << get_atomic_suffix_msvc(ordering);
+                m_of << "(";
                 };
             auto emit_atomic_cast = [&]() {
                 m_of << "(_Atomic "; emit_ctype(params.m_types.at(0)); m_of << "*)";
@@ -4442,7 +4480,7 @@ namespace {
                     break;
                 case Compiler::Msvc:
                     emit_lvalue(e.ret_val); m_of << "._0 = ";
-                    emit_msvc_atomic_op("InterlockedCompareExchange", Ordering::SeqCst, true);  // TODO: Use ordering, but which one?
+                    emit_msvc_atomic_op("InterlockedCompareExchange", Ordering::SeqCst);  // TODO: Use ordering, but which one?
                     // Slot, Exchange (new value), Comparand (expected value) - Note different order to the gcc/stdc version
                     emit_param(e.args.at(0)); m_of << ", "; emit_param(e.args.at(2)); m_of << ", "; emit_param(e.args.at(1)); m_of << ")";
                     m_of << ";\n\t";
@@ -4467,30 +4505,11 @@ namespace {
                     m_of << "("; emit_atomic_cast(); emit_param(e.args.at(0)); m_of << ", "; emit_param(e.args.at(1)); m_of << ", " << get_atomic_ty_gcc(ordering) << ")";
                     break;
                 case Compiler::Msvc:
-                    if( params.m_types.at(0) == ::HIR::CoreType::U8 || params.m_types.at(0) == ::HIR::CoreType::I8 )
-                    {
-                        //_InterlockedCompareExchange8 ?
-                        if( params.m_types.at(0) == ::HIR::CoreType::U8 )
-                            m_of << "*(volatile uint8_t*)";
-                        else
-                            m_of << "*(volatile int8_t*)";
-                        emit_param(e.args.at(0));
-                        switch(op)
-                        {
-                        case AtomicOp::Add: m_of << " += "; break;
-                        case AtomicOp::Sub: m_of << " -= "; break;
-                        case AtomicOp::And: m_of << " &= "; break;
-                        case AtomicOp::Or:  m_of << " |= "; break;
-                        case AtomicOp::Xor: m_of << " ^= "; break;
-                        }
-                        emit_param(e.args.at(1));
-                        return ;
-                    }
                     switch(op)
                     {
-                    case AtomicOp::Add: emit_msvc_atomic_op("InterlockedExchangeAdd", ordering, true);    break;
+                    case AtomicOp::Add: emit_msvc_atomic_op("InterlockedExchangeAdd", ordering);    break;
                     case AtomicOp::Sub:
-                        emit_msvc_atomic_op("InterlockedExchangeAdd", ordering, true);
+                        emit_msvc_atomic_op("InterlockedExchangeAdd", ordering);
                         emit_param(e.args.at(0)); m_of << ", ~(";
                         emit_param(e.args.at(1)); m_of << ")+1)";
                         return ;
@@ -5308,7 +5327,7 @@ namespace {
                     break;
                 case Compiler::Msvc:
                     //emit_msvc_atomic_op("InterlockedRead", ordering); emit_param(e.args.at(0)); m_of << ")";
-                    emit_msvc_atomic_op("InterlockedCompareExchange", ordering, true); emit_param(e.args.at(0)); m_of << ", 0, 0)";
+                    emit_msvc_atomic_op("InterlockedCompareExchange", ordering); emit_param(e.args.at(0)); m_of << ", 0, 0)";
                     break;
                 }
             }
@@ -5383,7 +5402,7 @@ namespace {
                 case Compiler::Msvc:
                     if(ordering == Ordering::Release)
                         ordering = Ordering::SeqCst;
-                    emit_msvc_atomic_op("InterlockedExchange", ordering, true);
+                    emit_msvc_atomic_op("InterlockedExchange", ordering);
                     emit_param(e.args.at(0)); m_of << ", ";
                     emit_param(e.args.at(1)); m_of << ")";
                     break;


### PR DESCRIPTION
* codegen_c targeted some functions (mostly -NoFence/Acquire/Release variants) that doesn't exist on MSVC.
* 8 bit arithmetic operations produced the wrong return value. The operations should return the original value, not the modified value.

This change adds `#defines` for the missing operations; mapping the NoFence/Acquire/Release variants to the unsuffixed version when not available.

The 8 bit operations are fixed by using the 8 bit functions.