### PR TITLE
codegen_c - Increase default stack size on MSVC

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -995,6 +995,7 @@ namespace {
                 args.push_back("&");
                 args.push_back("cl.exe");
                 args.push_back("/nologo");
+                args.push_back("/F8388608"); // Set max stack size to 8 MB.
                 args.push_back(m_outfile_path_c.c_str());
                 switch(opt.opt_level)
                 {


### PR DESCRIPTION
The default stack size of 1MB on MSVC causes an mrustc-compiled rustc to hit stack overflow. This change increases the stack size to 8MB.