### PR TITLE
codegen_c - MSVC: only reference obj files coming from rlibs

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1032,7 +1032,9 @@ namespace {
 
                     for( const auto& crate : m_crate.m_ext_crates )
                     {
-                        args.push_back(crate.second.m_path + ".obj");
+                        if (crate.second.m_path.compare(crate.second.m_path.size() - 5, 5, ".rlib") == 0) {
+                            args.push_back(crate.second.m_path + ".obj");
+                        }
                     }
                     // Crate-specified libraries
                     for(const auto& lib : m_crate.m_ext_libs) {


### PR DESCRIPTION
`Compiler::Gcc` has a check to only add `.o` files if the extern crate came from an `.rlib`. This change adds a similar check for MSVC.