### PR TITLE
Mostly x32 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ $(OBJDIR)%.o: src/%.cpp
 $(OBJDIR)version.o: $(OBJDIR)%.o: src/%.cpp $(filter-out $(OBJDIR)version.o,$(OBJ)) Makefile
 	@mkdir -p $(dir $@)
 	@echo [CXX] -o $@
-	$V$(CXX) -o $@ -c $< $(CXXFLAGS) $(CPPFLAGS) -MMD -MP -MF $@.dep -D VERSION_GIT_FULLHASH=\"$(shell git show --pretty=%H -s)\" -D VERSION_GIT_BRANCH="\"$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)\"" -D VERSION_GIT_SHORTHASH=\"$(shell git show -s --pretty=%h)\" -D VERSION_BUILDTIME="\"$(shell date -uR)\"" -D VERSION_GIT_ISDIRTY=$(shell git diff-index --quiet HEAD; echo $$?)
+	$V$(CXX) -o $@ -c $< $(CXXFLAGS) $(CPPFLAGS) -MMD -MP -MF $@.dep -D VERSION_GIT_FULLHASH=\"$(shell git show --pretty=%H -s --no-show-signature)\" -D VERSION_GIT_BRANCH="\"$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)\"" -D VERSION_GIT_SHORTHASH=\"$(shell git show -s --pretty=%h --no-show-signature)\" -D VERSION_BUILDTIME="\"$(shell date -uR)\"" -D VERSION_GIT_ISDIRTY=$(shell git diff-index --quiet HEAD; echo $$?)
 
 src/main.cpp: $(PCHS:%=src/%.gch)
 

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -22,6 +22,12 @@ const TargetArch ARCH_X86_64 = {
     TargetArch::Atomics(/*atomic(u8)=*/true, /*atomic(u16)=*/true, /*atomic(u32)=*/true, true,  true),
     TargetArch::Alignments(2, 4, 8, 16, 4, 8, 8)
     };
+const TargetArch ARCH_X32 = {
+    "x86_64",
+    32, false,
+    ARCH_X86_64.m_atomics,
+    TargetArch::Alignments(2, 4, 8, 16, 4, 8, 4)    // x86_64 w/4-byte ptr
+};
 const TargetArch ARCH_X86 = {
     "x86",
     32, false,
@@ -383,6 +389,13 @@ namespace
             return TargetSpec {
                 "unix", "linux", "gnu", {CodegenMode::Gnu11, false, "x86_64-linux-gnu", BACKEND_C_OPTS_GNU},
                 ARCH_X86_64
+                };
+        }
+        else if(target_name == "x86_64-unknown-linux-gnux32")
+        {
+            return TargetSpec {
+                "unix", "linux", "gnu", {CodegenMode::Gnu11, true, "x86_64-unknown-linux-gnux32", BACKEND_C_OPTS_GNU},
+                ARCH_X32
                 };
         }
         else if(target_name == "arm-linux-gnu")

--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -17,7 +17,11 @@
 // - Linux
 #elif defined(__linux__)
 # if defined(__amd64__)
-#  define DEFAULT_TARGET_NAME "x86_64-linux-gnu"
+#  if defined(_ILP32)
+#   define DEFAULT_TARGET_NAME "x86_64-unknown-linux-gnux32"
+#  else
+#   define DEFAULT_TARGET_NAME "x86_64-linux-gnu"
+#  endif
 # elif defined(__aarch64__)
 #  define DEFAULT_TARGET_NAME "aarch64-linux-gnu"
 # elif defined(__arm__)


### PR DESCRIPTION
mrustc disagrees on the size of one type (`union u_ZRG3c3std9panickingh0134Data2gG2c3std5panic16AssertUnwindSafe1gG3c17rustc_incremental7persist4loadh7closure16load_dep_g$d67c7ee6`) when building rustc 1.29.0, which, when ignored (or, indeed, `__attribute__((packed))` away), produces a rustc that panics with
```
thread 'main' panicked at 'assertion failed: ((probe).index() != idx_end)', rustc-1.29.0-src/src/libstd/collections/hash/map.rs:541:53
```

rustc may be terminally broken, but this mrustc does work for simple x32 executables, so I'm opening this PR either way, could be useful for someone smarter than me