### PR TITLE
Add initial support for ppc64

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -44,6 +44,18 @@ const TargetArch ARCH_M68K = {
     { /*atomic(u8)=*/true, false, true, false,  true },
     TargetArch::Alignments(2, 2, 2, 2, 2, 2, 2)
 };
+const TargetArch ARCH_POWERPC64 = {
+    "powerpc64",
+    64, true,
+    { /*atomic(u8)=*/true, true, true, true,  true },
+    TargetArch::Alignments(2, 4, 8, 16, 4, 8, 8)
+};
+const TargetArch ARCH_POWERPC64LE = {
+    "powerpc64",
+    64, false,
+    { /*atomic(u8)=*/true, true, true, true,  true },
+    TargetArch::Alignments(2, 4, 8, 16, 4, 8, 8)
+};
 TargetSpec  g_target;
 
 
@@ -402,6 +414,20 @@ namespace
             return TargetSpec {
                 "unix", "linux", "gnu", {CodegenMode::Gnu11, true, "m68k-linux-gnu", BACKEND_C_OPTS_GNU},
                 ARCH_M68K
+                };
+        }
+        else if(target_name == "powerpc64-unknown-linux-gnu")
+        {
+            return TargetSpec {
+                "unix", "linux", "gnu", {CodegenMode::Gnu11, false, "powerpc64-unknown-linux-gnu", BACKEND_C_OPTS_GNU},
+                ARCH_POWERPC64
+                };
+        }
+        else if(target_name == "powerpc64le-unknown-linux-gnu")
+        {
+            return TargetSpec {
+                "unix", "linux", "gnu", {CodegenMode::Gnu11, false, "powerpc64le-unknown-linux-gnu", BACKEND_C_OPTS_GNU},
+                ARCH_POWERPC64LE
                 };
         }
         else if(target_name == "i586-pc-windows-gnu")

--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -26,6 +26,10 @@
 #  define DEFAULT_TARGET_NAME "i586-linux-gnu"
 # elif defined(__m68k__)
 #  define DEFAULT_TARGET_NAME "m68k-linux-gnu"
+# elif defined(__powerpc64__) && defined(__BIG_ENDIAN__)
+#  define DEFAULT_TARGET_NAME "powerpc64-unknown-linux-gnu"
+# elif defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
+#  define DEFAULT_TARGET_NAME "powerpc64le-unknown-linux-gnu"
 # else
 #  warning "Unable to detect a suitable default target (linux-gnu)"
 # endif


### PR DESCRIPTION
Note, I couldn't get a complete build to work... Got as far as `(95/96) BUILDING cargo v0.30.0` though.

```
[RUSTC] -o output/prefix-s/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libcore.rlib
make: *** [Makefile:120: output/prefix-s/lib/rustlib/powerpc64le-unknown-linux-gnu/lib/libcore.rlib] Segmentation fault
```
