### PR TITLE
make: Replace make by $(MAKE)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ RUST_TESTS: RUST_TESTS_run-pass
 RUST_TESTS_run-pass: output$(OUTDIR_SUF)/test/librust_test_helpers.a
 	@$(MAKE) -C tools/testrunner
 	@mkdir -p output$(OUTDIR_SUF)/rust_tests/run-pass
-	make -f minicargo.mk output$(OUTDIR_SUF)/test/libtest.so
+	$(MAKE) -f minicargo.mk output$(OUTDIR_SUF)/test/libtest.so
 	./bin/testrunner -L output$(OUTDIR_SUF)/test -o output$(OUTDIR_SUF)/rust_tests/run-pass $(RUST_TESTS_DIR)run-pass --exceptions disabled_tests_run-pass.txt
 output$(OUTDIR_SUF)/test/librust_test_helpers.a: output$(OUTDIR_SUF)/test/rust_test_helpers.o
 	@mkdir -p $(dir $@)
@@ -256,7 +256,7 @@ output$(OUTDIR_SUF)/test/rust_test_helpers.o: $(RUST_TEST_HELPERS_C)
 # 
 .PHONY: rust_tests-libs
 rust_tests-libs: $(TEST_DEPS)
-	make -f minicargo.mk $@
+	$(MAKE) -f minicargo.mk $@
 
 
 .PHONY: test

--- a/run_rustc/Makefile
+++ b/run_rustc/Makefile
@@ -52,9 +52,9 @@ RUSTFLAGS_alloc_system :=
 RUSTFLAGS_compiler_builtins := --cfg feature=\"compiler-builtins\"
 
 ../output$(OUTDIR_SUF)/rustc:
-	make -C ../ output$(OUTDIR_SUF)/rustc -j 3
+	$(MAKE) -C ../ output$(OUTDIR_SUF)/rustc -j 3
 ../output$(OUTDIR_SUF)/cargo:
-	make -C ../ output$(OUTDIR_SUF)/cargo -j 3
+	$(MAKE) -C ../ output$(OUTDIR_SUF)/cargo -j 3
 
 $(BINDIR)rustc_m: ../output$(OUTDIR_SUF)/rustc
 	@mkdir -p $(dir $@)

--- a/tools/dump_hirfile/Makefile
+++ b/tools/dump_hirfile/Makefile
@@ -51,7 +51,7 @@ $(OBJDIR)%.o: ../../src/%.cpp
 	$V$(CXX) -o $@ -c $< $(CXXFLAGS) -MMD -MP -MF $@.dep
 
 $(COMMON_LIB): $(wildcard ../common/*.* ../common/Makefile)
-	make -C ../common
+	$(MAKE) -C ../common
 
 -include $(OBJS:%.o=%.o.dep)
 

--- a/tools/minicargo/Makefile
+++ b/tools/minicargo/Makefile
@@ -46,7 +46,7 @@ $(OBJDIR)%.o: %.cpp
 	$V$(CXX) -o $@ -c $< $(CXXFLAGS) -MMD -MP -MF $@.dep
 
 ../../bin/common_lib.a: $(wildcard ../common/*.* ../common/Makefile)
-	make -C ../common
+	$(MAKE) -C ../common
 
 -include $(OBJS:%.o=%.o.dep)
 

--- a/tools/mir_opt_test/Makefile
+++ b/tools/mir_opt_test/Makefile
@@ -42,9 +42,9 @@ $(OBJDIR)%.o: %.cpp
 	@echo [CXX] $<
 	$V$(CXX) -o $@ -c $< $(CXXFLAGS) -MMD -MP -MF $@.dep
 ../../bin/mrustc.a:
-	make -C ../../ bin/mrustc.a
+	$(MAKE) -C ../../ bin/mrustc.a
 ../../bin/common_lib.a:
-	make -C ../common
+	$(MAKE) -C ../common
 
 -include $(OBJS:%.o=%.o.dep)
 

--- a/tools/standalone_miri/Makefile
+++ b/tools/standalone_miri/Makefile
@@ -46,7 +46,7 @@ $(OBJDIR)%.o: ../../src/%.cpp
 	$V$(CXX) -o $@ -c $< $(CXXFLAGS) -MMD -MP -MF $@.dep
 
 $(COMMON_LIB):
-	make -C ../common
+	$(MAKE) -C ../common
 
 -include $(OBJS:%.o=%.o.dep)
 


### PR DESCRIPTION
Macro MAKE is defined in POSIX make:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html#tag_20_76_13_09

On my system, `make` is BSD make and `gmake` is GNU make. Because mrustc uses the GNU make syntax, I must explicitly call `gmake` when building it. The issue is that `gmake` will execute `make`, which is not the GNU version. So by using the standard variable, when I execute `gmake`, `MAKE` variable would automatically be set to `gmake`. This behavior solves my issue.

Thank you.