### PR TITLE
i386-gnu target for GNU/Hurd

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -4183,7 +4183,7 @@ namespace {
 
             m_of << indent << "__asm__ ";
             if (is_volatile) m_of << "__volatile__";
-            m_of << "(\"" << (is_intel ? ".syntax intel; " : "");
+            m_of << "(\"" << (is_intel ? ".intel_syntax; " : "");
             // TODO: Use a more powerful parser
             for (auto it = e.tpl.begin(); it != e.tpl.end(); ++it)
             {
@@ -4214,7 +4214,7 @@ namespace {
                 else
                     m_of << *it;
             }
-            m_of << (is_intel ? ".syntax att; " : "") << "\"";
+            m_of << (is_intel ? ".att_syntax; " : "") << "\"";
             m_of << ": ";
             for (unsigned int i = 0; i < e.outputs.size(); i++)
             {

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -372,6 +372,13 @@ namespace
         {
             return load_spec_from_file(target_name);
         }
+        else if(target_name == "i386-gnu")
+        {
+            return TargetSpec {
+                "unix", "hurd", "gnu", {CodegenMode::Gnu11, true, "i386-gnu", BACKEND_C_OPTS_GNU},
+                ARCH_X86
+                };
+        }
         else if(target_name == "i586-linux-gnu")
         {
             return TargetSpec {

--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -84,6 +84,8 @@
 # else
 #  warning "Unable to detect a suitable default target (Haiku)"
 # endif
+#elif defined(__GNU__)
+# define DEFAULT_TARGET_NAME "i386-gnu"
 // - Unknown
 #else
 # warning "Unable to detect a suitable default target"


### PR DESCRIPTION
This branch gets you most of the way to a complete port on GNU/Hurd.
There is a bug in rustc 1.29 sources that prevents this mrustc from compiling rustc on hurd.
(I believe the `popfd` and `pushfd` instructions are only valid when using `.intel_syntax` in GAS on i386)

We still need to port the libstd to os hurd target.