### PR TITLE
Enable bootstrap of rustc 1.39.0 on Windows

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1666,7 +1666,6 @@ namespace {
                 }
                 else if( TU_TEST1(ty.data(), Path, .binding.is_ExternType()) ) {
                     m_of << "// External";
-                    has_unsized = true;
                 }
                 else {
                     if( s == 0 && m_options.disallow_empty_structs ) {

--- a/tools/backend_c/backend_c.cpp
+++ b/tools/backend_c/backend_c.cpp
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[])
                 rv = get_ord(t2, t1);
                 return rv == OrdGreater;
             }
-            bool operator()(const HIR::TypeRef& t1, const HIR::TypeRef& t2) {
+            bool operator()(const HIR::TypeRef& t1, const HIR::TypeRef& t2) const {
                 return t1 < t2;
             }
         };

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -1358,6 +1358,56 @@ const helpers::path& get_mrustc_path()
     return s_compiler_path;
 }
 
+#ifdef _WIN32
+// Escapes an argument for CommandLineToArgv on Windows
+void argv_quote_windows(const std::string& arg, std::stringstream& cmdline)
+{
+    if (arg.empty()) return;
+    // Add a space to start a new argument.
+    cmdline << " ";
+
+    // Don't quote unless we need to
+    if (arg.find_first_of(" \t\n\v\"") == arg.npos)
+    {
+        cmdline << arg;
+        return;
+    }
+    else
+    {
+        cmdline << '"';
+        for (auto ch = arg.begin(); ; ++ch) {
+            size_t backslash_count = 0;
+
+            // Count backslashes
+            while (ch != arg.end() && *ch == L'\\') {
+                ++ch;
+                ++backslash_count;
+            }
+
+            if (ch == arg.end()) {
+                // Escape backslashes, but let the terminating
+                // double quotation mark we add below be interpreted
+                // as a metacharacter.
+                for (int i = 0; i < backslash_count * 2; i++) cmdline << '\\';
+                break;
+            }
+            else if (*ch == L'"')
+            {
+                // Escape backslashes and the following double quotation mark.
+                for (int i = 0; i < backslash_count * 2 + 1; i++) cmdline << '\\';
+                cmdline << *ch;
+            }
+            else
+            {
+                for (int i = 0; i < backslash_count; i++) cmdline << '\\';
+                cmdline << *ch;
+            }
+        }
+        cmdline << '"';
+    }
+}
+#endif
+
 bool spawn_process(const char* exe_name, const StringList& args, const StringListKV& env, const ::helpers::path& logfile, const ::helpers::path& working_directory/*={}*/)
 {
     if( getenv("MINICARGO_DUMPENV") )
@@ -1374,8 +1424,7 @@ bool spawn_process(const char* exe_name, const StringList& args, const StringLis
     ::std::stringstream cmdline;
     cmdline << exe_name;
     for (const auto& arg : args.get_vec())
-        // TODO: Escaping rules (quote if spaces, `^` before interior quotes or `^`)
-        cmdline << " " << arg;
+        argv_quote_windows(arg, cmdline);
     auto cmdline_str = cmdline.str();
     if(true)
     {

--- a/vsproject/bootstrap_139.cmd
+++ b/vsproject/bootstrap_139.cmd
@@ -1,0 +1,109 @@
+@REM Builds rustc 1.39.0 using mrustc-built rustc 1.39.0
+@REM INPUTS
+@REM - mrustc-built rustc & cargo
+@REM   Build using build_rustc_minicargo_139.cmd AND build_cargo_minicargo_139.cmd
+@REM - LLVM: either by setting LLVM_CONFIG or using %OUTDIR%llvm-prefix
+@REM   which is built by build_rustc_minicargo_139.cmd
+@REM OUTPUTS
+@REM - rust sysroot in output-1.39.0\prefix
+
+@setlocal
+@call build_std_139.cmd
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+set RUST_SRC=%~dp0..\rustc-%RUSTC_VERSION%-src\src\
+set VENDOR_DIR=%RUST_SRC%..\vendor
+
+@REM Stage X: Standard library built using `rustc` (using cargo)
+set PREFIX=%OUTDIR%prefix\
+set BINDIR=%PREFIX%bin\
+set LIBDIR=%PREFIX%\lib\rustlib\%RUSTC_TARGET%\lib\
+set CARGO_HOME=%PREFIX%cargo_home\
+@REM Stage 2: standard library built with `rustc` (using minicargo)
+set PREFIX_2=%OUTDIR%prefix-2\
+set LIBDIR_2=%PREFIX_2%lib\rustlib\%RUSTC_TARGET%\lib\
+set BINDIR_2=%PREFIX_2%bin\
+@REM Stage 1: standard library built with `rustc_m` (using minicargo)
+set PREFIX_S=%OUTDIR%prefix-s\
+set LIBDIR_S=%PREFIX_S%lib\rustlib\%RUSTC_TARGET%\lib\
+set BINDIR_S=%PREFIX_S%bin\
+
+set CFG_RELEASE=%RUSTC_VERSION%
+set CFG_RELEASE_CHANNEL=stable
+set CFG_VERSION=%RUSTC_VERSION%-stable-mrustc
+set CFG_PREFIX=mrustc
+set CFG_LIBDIR_RELATIVE=lib
+set REAL_LIBRARY_PATH_VAR=PATH
+set REAL_LIBRARY_PATH=%PATH%
+set RUSTC_INSTALL_BINDIR=bin
+set RUSTC_BOOTSTRAP=1
+set CXXFLAGS=/MT
+
+mkdir %BINDIR%
+mkdir %BINDIR_2%
+mkdir %BINDIR_S%
+mkdir %LIBDIR%
+mkdir %LIBDIR_2%
+mkdir %LIBDIR_S%
+mkdir %CARGO_HOME%
+
+@REM Copy bootstrapping binaries
+copy %OUTDIR%rustc-build\rustc_binary.exe %BINDIR_S%rustc.exe
+copy %OUTDIR%cargo-build\cargo.exe %BINDIR%\cargo.exe
+
+echo [source.crates-io] > %CARGO_HOME%config
+echo replace-with = "vendored-sources" >> %CARGO_HOME%config
+echo [source.vendored-sources] >> %CARGO_HOME%config
+echo directory = "%VENDOR_DIR:\=\\%" >> %CARGO_HOME%config
+
+@REM Build libstd using minicargo + rustc
+set MRUSTC_PATH=%~dp0%BINDIR_S%rustc.exe
+x64\Release\minicargo.exe %RUST_SRC%libstd --vendor-dir %VENDOR_DIR% --script-overrides ../script-overrides/stable-%RUSTC_VERSION%-windows/ --output-dir %LIBDIR_S%
+@if %errorlevel% neq 0 exit /b %errorlevel%
+x64\Release\minicargo.exe %RUST_SRC%libtest --vendor-dir %VENDOR_DIR% --script-overrides ../script-overrides/stable-%RUSTC_VERSION%-windows/ --output-dir %LIBDIR_S%
+@if %errorlevel% neq 0 exit /b %errorlevel%
+set MRUSTC_PATH=
+
+@REM Build rustc with itself (so we have a rustc with the right ABI)
+@IF "%LLVM_CONFIG%"=="" set LLVM_CONFIG=%~dp0%OUTDIR%llvm-prefix\bin\llvm-config.exe
+set TMPDIR=%~dp0%PREFIX%tmp
+set CARGO_TARGET_DIR=%OUTDIR%bootstrap-rustc\
+set RUSTC=%BINDIR_S%rustc
+set RUSTFLAGS=-Z force-unstable-if-unmarked
+set RUSTC_BOOTSTRAP=1
+set RUSTC_ERROR_METADATA_DST=%PREFIX%
+set CFG_RELEASE_CHANNEL=stable
+set CFG_PREFIX=mrustc
+set CFG_LIBDIR_RELATIVE=lib
+mkdir %TMPDIR%
+mkdir %CARGO_TARGET_DIR%
+%BINDIR%cargo build --manifest-path %RUST_SRC%rustc/Cargo.toml --release -j 1 --verbose
+@if %errorlevel% neq 0 exit /b %errorlevel%
+%BINDIR%cargo rustc --manifest-path %RUST_SRC%librustc_codegen_llvm/Cargo.toml --release -j 1 --verbose -- -L %~dp0%CARGO_TARGET_DIR%release\deps
+@if %errorlevel% neq 0 exit /b %errorlevel%
+copy /y %LIBDIR%*.dll %BINDIR%
+copy /y %CARGO_TARGET_DIR%release\deps\*.rlib %LIBDIR%
+copy /y %CARGO_TARGET_DIR%release\deps\*.dll* %LIBDIR%
+copy /y %CARGO_TARGET_DIR%release\deps\*.dll %BINDIR%
+copy /y %CARGO_TARGET_DIR%release\rustc_binary.exe %BINDIR%rustc.exe
+mkdir %LIBDIR%..\codegen-backends
+copy /y %CARGO_TARGET_DIR%release\rustc_codegen_llvm.dll %LIBDIR%..\codegen-backends\rustc_codegen_llvm-llvm.dll
+
+@REM Build libstd and friends with the final rustc, but using minicargo (to avoid running build scripts)
+mkdir %LIBDIR_2%..\codegen-backends
+copy /y %BINDIR%rustc.exe %BINDIR_2%rustc.exe
+copy /y %BINDIR%*.dll %BINDIR_2%
+copy /y %LIBDIR%..\codegen-backends\rustc_codegen_llvm-llvm.dll %LIBDIR_2%..\codegen-backends\
+set MRUSTC_PATH=%BINDIR%rustc.exe
+x64\Release\minicargo.exe %RUST_SRC%libtest --vendor-dir %VENDOR_DIR% --script-overrides ../script-overrides/stable-%RUSTC_VERSION%-windows/ --output-dir %LIBDIR_2%
+@if %errorlevel% neq 0 exit /b %errorlevel%
+set MRUSTC_PATH=
+
+@REM Actual libstd build (using cargo, and using the above-built libstd as deps)
+set CARGO_TARGET_DIR=%OUTDIR%bootstrap-std\
+set RUSTC=%BINDIR_2%rustc.exe
+%BINDIR%cargo build --manifest-path %RUST_SRC%libtest\Cargo.toml -j 1 --release --features panic-unwind -v
+@if %errorlevel% neq 0 exit /b %errorlevel%
+copy /y %CARGO_TARGET_DIR%release\deps\*.rlib %LIBDIR%
+copy /y %CARGO_TARGET_DIR%release\deps\*.dll* %LIBDIR%
+

--- a/vsproject/build_cargo_minicargo_139.cmd
+++ b/vsproject/build_cargo_minicargo_139.cmd
@@ -1,8 +1,8 @@
 @call build_std_139.cmd
 @if %errorlevel% neq 0 exit /b %errorlevel%
 
-@mkdir %OUTDIR%\cargo-build
-x64\Release\minicargo.exe ..\rustc-%RUSTC_VERSION%-src\src\tools\cargo -L %OUTDIR% --output-dir %OUTDIR%\cargo-build %COMMON_ARGS%
+@mkdir %OUTDIR%cargo-build
+x64\Release\minicargo.exe ..\rustc-%RUSTC_VERSION%-src\src\tools\cargo -L %OUTDIR% --output-dir %OUTDIR%cargo-build %COMMON_ARGS%
 @if %errorlevel% neq 0 exit /b %errorlevel%
 
-%OUTDIR%\cargo-build\cargo.exe --version
+%OUTDIR%cargo-build\cargo.exe --version

--- a/vsproject/build_rustc_minicargo_139.cmd
+++ b/vsproject/build_rustc_minicargo_139.cmd
@@ -1,0 +1,41 @@
+@setlocal
+@call build_std_139.cmd
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+@IF "%LLVM_CONFIG%"=="" (
+    @REM Build LLVM
+    @mkdir %OUTDIR%llvm-build
+    pushd %OUTDIR%llvm-build
+    cmake "%~dp0..\rustc-%RUSTC_VERSION%-src\src\llvm-project\llvm" "-G" "Ninja" "-DLLVM_ENABLE_ASSERTIONS=OFF" ^
+    "-DLLVM_TARGETS_TO_BUILD=X86"  "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=" ^
+    "-DLLVM_INCLUDE_EXAMPLES=OFF" "-DLLVM_INCLUDE_TESTS=OFF" "-DLLVM_INCLUDE_DOCS=OFF" ^
+    "-DLLVM_INCLUDE_BENCHMARKS=OFF" "-DLLVM_ENABLE_ZLIB=OFF" "-DWITH_POLLY=OFF" "-DLLVM_ENABLE_TERMINFO=OFF" ^
+    "-DLLVM_ENABLE_LIBEDIT=OFF" "-DLLVM_ENABLE_Z3_SOLVER=OFF" ^
+    "-DLLVM_TARGET_ARCH=x86_64" "-DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-pc-windows-msvc" ^
+    "-DLLVM_USE_CRT_DEBUG=MT" "-DLLVM_USE_CRT_RELEASE=MT" "-DLLVM_USE_CRT_RELWITHDEBINFO=MT" "-DLLVM_ENABLE_LIBXML2=OFF" ^
+    "-DLLVM_VERSION_SUFFIX=-rust-1.39.0-mrustc" "-DCMAKE_INSTALL_MESSAGE=LAZY" ^
+    "-DCMAKE_C_FLAGS=/nologo /MT" "-DCMAKE_CXX_FLAGS=/nologo /MT" ^
+    "-DCMAKE_INSTALL_PREFIX=%~dp0%OUTDIR%llvm-prefix" "-DCMAKE_BUILD_TYPE=Release"
+    popd
+    @if %errorlevel% neq 0 exit /b %errorlevel%
+
+    cmake --build %OUTDIR%llvm-build --target install --config Release
+    @if %errorlevel% neq 0 exit /b %errorlevel%
+
+    set LLVM_CONFIG=%~dp0%OUTDIR%llvm-prefix\bin\llvm-config.exe
+)
+
+@mkdir %OUTDIR%rustc-build
+set CFG_RELEASE=%RUSTC_VERSION%
+set CFG_VERSION=%RUSTC_VERSION%-stable-mrustc
+
+@set REAL_LIBRARY_PATH_VAR=PATH
+@set REAL_LIBRARY_PATH=%PATH%
+@set RUSTC_INSTALL_BINDIR=bin
+@set CXXFLAGS=/MT
+
+echo HOST_TRIPLE = %CFG_COMPILER_HOST_TRIPLE%
+x64\Release\minicargo.exe ..\rustc-%RUSTC_VERSION%-src\src\rustc -L %OUTDIR% --output-dir %OUTDIR%rustc-build %COMMON_ARGS%
+@if %errorlevel% neq 0 exit /b %errorlevel%
+
+%OUTDIR%rustc-build\rustc_binary.exe --version

--- a/vsproject/build_std_139.cmd
+++ b/vsproject/build_std_139.cmd
@@ -1,6 +1,8 @@
 @set RUSTC_VERSION=1.39.0
 @set MRUSTC_TARGET_VER=1.39
-@set OUTDIR=output-%RUSTC_VERSION%
+@set RUSTC_TARGET=x86_64-pc-windows-msvc
+@set CFG_COMPILER_HOST_TRIPLE=%RUSTC_TARGET%
+@set OUTDIR=output-%RUSTC_VERSION%\
 @set COMMON_ARGS=--vendor-dir ..\rustc-%RUSTC_VERSION%-src\vendor --manifest-overrides ..\rustc-%RUSTC_VERSION%-overrides.toml
 @if defined PARLEVEL ( set COMMON_ARGS=%COMMON_ARGS% -j %PARLEVEL% )
 @set STD_ARGS=--output-dir %OUTDIR% %COMMON_ARGS%

--- a/vsproject/mrustc.vcxproj
+++ b/vsproject/mrustc.vcxproj
@@ -169,6 +169,7 @@
       <AdditionalDependencies>common_lib.lib;mrustc_lib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
       <AdditionalOptions>/WHOLEARCHIVE:mrustc_lib.lib %(AdditionalOptions)</AdditionalOptions>
+      <StackReserveSize>8388608</StackReserveSize>
       <Profile>true</Profile>
     </Link>
     <ProjectReference />


### PR DESCRIPTION
* Adds bootstrapping scripts for 1.39.0 on Windows
* Increase stack size for mrustc to avoid stack overflow
* Add argument quoting for minicargo
* Minor fixes