### PR TITLE
Fix macro_rules macros that match unions

### DIFF
--- a/src/macro_rules/eval.cpp
+++ b/src/macro_rules/eval.cpp
@@ -1586,6 +1586,8 @@ namespace
                 }
                 else
                 {
+                    if( !lex.consume_if(TOK_IDENT) )
+                        return false;
                     if( !H::maybe_generics(lex) )
                         return false;
                     if( !H::maybe_where(lex) )


### PR DESCRIPTION
`macro_rules!` macros that matched items failed to match `union`s because the parser did not account for the union having a name.

For example, the following macro failed to accept union type definitions:
```rust
macro_rules! __item {
    ($i:item) => {
        $i
    };
}
```