### PR TITLE
Fix build error (ptrdiff_t) with GCC 5/6

### DIFF
--- a/src/include/range_vec_map.hpp
+++ b/src/include/range_vec_map.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Without `<cstddef>`, building with GCC 5/6 produces the error:

```
error: 'ptrdiff_t' does not name a type
```