### PR TITLE
Codegen C - Add braces around 128-bit literals

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -6992,9 +6992,10 @@ namespace {
                         }
                         else
                         {
-                            m_of << "(int128_t)";
+                            m_of << "(int128_t){";
                             m_of << c.v;
                             m_of << "ll";
+                            m_of << "}";
                         }
                         break;
                     default:
@@ -7026,8 +7027,9 @@ namespace {
                     }
                     else
                     {
-                        m_of << "(uint128_t)";
+                        m_of << "(uint128_t){";
                         m_of << ::std::hex << "0x" << c.v << "ull" << ::std::dec;
+                        m_of << "}";
                     }
                     break;
                 case ::HIR::CoreType::Char:


### PR DESCRIPTION
Constants with types larger than the pointer size need literal braces so that their address can be taken in an argument-passing context.

Fixes #198 