### PR TITLE
Allow using system-installed LLVM

### DIFF
--- a/minicargo.mk
+++ b/minicargo.mk
@@ -239,7 +239,7 @@ LLVM_CMAKE_OPTS += CMAKE_BUILD_TYPE=Release
 LLVM_CMAKE_OPTS += $(LLVM_CMAKE_OPTS_EXTRA)
 
 
-$(LLVM_CONFIG): $(RUSTCSRC)build/Makefile
+$(RUSTCSRC)build/bin/llvm-config: $(RUSTCSRC)build/Makefile
 	$Vcd $(RUSTCSRC)build && $(MAKE)
 
 $(RUSTCSRC)build/Makefile: $(RUSTCSRC)$(LLVM_DIR)/CMakeLists.txt


### PR DESCRIPTION
It's now possible to override MINICARGO and LLVM_CONFIG to use dependencies from outside the source tree. This is helpful for iterating on packaging, as the bootstrap can be split up into multiple packages.