### PR TITLE
Lex - include missing <limits> header

### DIFF
--- a/src/parse/lex.cpp
+++ b/src/parse/lex.cpp
@@ -14,6 +14,7 @@
 #include <cstdlib>  // strtol
 #include <typeinfo>
 #include <algorithm>    // std::count
+#include <limits>       // std::numeric_limits
 #include <cctype>
 //#define TRACE_CHARS
 //#define TRACE_RAW_TOKENS


### PR DESCRIPTION
Compilation fails with GCC 11 without this change.