### PR TITLE
Fixed segmentation fault on huge paths

### DIFF
--- a/tools/common/path.cpp
+++ b/tools/common/path.cpp
@@ -10,6 +10,7 @@
 # include <Windows.h>
 #else
 # include <unistd.h>    // getcwd/chdir
+# include <limits.h> // PATH_MAX
 #endif
 
 helpers::path::path(const char* s):
@@ -50,7 +51,7 @@ helpers::path helpers::path::to_absolute() const
     char cwd[1024];
     GetCurrentDirectoryA(sizeof(cwd), cwd);
     #else
-    char cwd[1024];
+    char cwd[PATH_MAX];
     if( !getcwd(cwd, sizeof(cwd)) )
         throw ::std::runtime_error("Calling getcwd() failed in path::to_absolute()");
     #endif

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -44,6 +44,7 @@ extern int _putenv_s(const char*, const char*);
 # include <sys/stat.h>
 # include <sys/wait.h>
 # include <fcntl.h>
+# include <limits.h> // PATH_MAX
 #endif
 #ifdef __APPLE__
 # include <mach-o/dyld.h>
@@ -1318,7 +1319,7 @@ const helpers::path& get_mrustc_path()
         // MSVC, minicargo and mrustc are in the same dir
         s_compiler_path = minicargo_path / "mrustc.exe";
 #else
-        char buf[1024];
+        char buf[PATH_MAX];
 # ifdef __linux__
         ssize_t s = readlink("/proc/self/exe", buf, sizeof(buf)-1);
         if(s >= 0)


### PR DESCRIPTION
When path to a folder where mrustc huge the hardcoded buffer for `1024` char might not be enoug.

When it happened it corrupts memmory which leads to segfault.

I have no idea how to get `PATH_MAX` on windows => I've touched only not windows build.