### PR TITLE
Bootstrapping for 1.54.0 for macOS 

### DIFF
--- a/run_rustc/Makefile
+++ b/run_rustc/Makefile
@@ -27,12 +27,12 @@ endif
 ifeq ($(shell uname -s || echo not),Darwin)
   DYLIB_EXT := dylib
   PLATFORM := macos
+  RUSTC_TARGET ?= x86_64-apple-darwin
 else
   DYLIB_EXT := so
   PLATFORM := linux
+  RUSTC_TARGET ?= x86_64-unknown-linux-gnu
 endif
-
-RUSTC_TARGET ?= x86_64-unknown-linux-gnu
 
 TARGETVER_LEAST_1_29 := $(shell test "$(RUSTC_VERSION)" ">" "1.29" && echo yes)
 TARGETVER_LEAST_1_39 := $(shell test "$(RUSTC_VERSION)" ">" "1.39" && echo yes)

--- a/rustc-1.54.0-src.patch
+++ b/rustc-1.54.0-src.patch
@@ -1,11 +1,26 @@
 # mrustc is much better at enum packing, so causes almost all of these to be smaller by one pointer
 --- compiler/rustc_ast/src/ast.rs
 +++ compiler/rustc_ast/src/ast.rs
-@@ -2782,2 +2782,2 @@
+@@ -1075,7 +1075,7 @@ pub struct Expr {
+ }
+ 
+ // `Expr` is used a lot. Make sure it doesn't unintentionally get bigger.
+-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
++#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
+ rustc_data_structures::static_assert_size!(Expr, 104);
+ 
+ impl Expr {
+@@ -2779,7 +2779,7 @@ pub enum AssocItemKind {
+     MacCall(MacCall),
+ }
+ 
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 +#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
  rustc_data_structures::static_assert_size!(AssocItemKind, 72);
-@@ -2832,6 +2832,6 @@
+ 
+ impl AssocItemKind {
+@@ -2831,7 +2831,7 @@ pub enum ForeignItemKind {
+     MacCall(MacCall),
  }
  
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]

--- a/script-overrides/stable-1.54.0-macos/build_compiler_builtins.txt
+++ b/script-overrides/stable-1.54.0-macos/build_compiler_builtins.txt
@@ -1,0 +1,2 @@
+#cargo:compiler-rt=
+cargo:rustc-cfg=feature="unstable"

--- a/script-overrides/stable-1.54.0-macos/build_libc.txt
+++ b/script-overrides/stable-1.54.0-macos/build_libc.txt
@@ -1,0 +1,10 @@
+cargo:rustc-cfg=darwin
+cargo:rustc-cfg=libc_priv_mod_use
+cargo:rustc-cfg=libc_union
+cargo:rustc-cfg=libc_const_size_o
+cargo:rustc-cfg=libc_align
+cargo:rustc-cfg=libc_core_cvoid
+cargo:rustc-cfg=libc_packedN
+cargo:rustc-cfg=libc_cfg_target_vendor
+cargo:rustc-cfg=libc_thread_local
+cargo:rustc-cfg=libc_const_extern_fn

--- a/script-overrides/stable-1.54.0-macos/build_std.txt
+++ b/script-overrides/stable-1.54.0-macos/build_std.txt
@@ -1,0 +1,2 @@
+cargo:rustc-cfg=backtrace_in_libstd
+cargo:rustc-env=STD_ENV_ARCH=x86_64

--- a/script-overrides/stable-1.54.0-macos/build_unwind.txt
+++ b/script-overrides/stable-1.54.0-macos/build_unwind.txt
@@ -1,0 +1,1 @@
+# No output for macos

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -2478,10 +2478,10 @@ namespace {
                     m_of << "\tif(arg0) rv._0 |= __builtin_add_overflow" << msvc_suffix_u32 << "(rv._1, 1, &rv._1);\n";
                     m_of << "\treturn rv;\n";
                 }
-                // `fn llvm_addcarryx_u32(a: u8, b: u32, c: u32, d: *mut u8) -> u32`
+                // `fn llvm_addcarryx_u32(a: u8, b: u32, c: u32, d: *mut u8) -> u8`
                 else if( item.m_linkage.name == "llvm.x86.addcarryx.u32") {
-                    m_of << "\t*arg3 = __builtin_add_overflow" << msvc_suffix_u32 << "(arg1, arg2, &rv);\n";
-                    m_of << "\tif(*arg3) *arg3 |= __builtin_add_overflow" << msvc_suffix_u32 << "(rv, 1, &rv);\n";
+                    m_of << "\trv = __builtin_add_overflow" << msvc_suffix_u32 << "(arg1, arg2, arg3);\n";
+                    m_of << "\tif(arg0) rv |= __builtin_add_overflow" << msvc_suffix_u32 << "(*arg3, 1, arg3);\n";
                     m_of << "\treturn rv;\n";
                 }
                 // `fn llvm_subborrow" << msvc_suffix_u32 << "(a: u8, b: u32, c: u32) -> (u8, u32);`

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -541,7 +541,7 @@ namespace
                 ARCH_X86_64
                 };
         }
-        else if(target_name == "x86_64-apple-macosx")
+        else if(target_name == "x86_64-apple-darwin")
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
             return TargetSpec {
@@ -549,7 +549,7 @@ namespace
                 ARCH_X86_64
                 };
         }
-        else if(target_name == "aarch64-apple-macosx")
+        else if(target_name == "aarch64-apple-darwin")
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
             return TargetSpec {

--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -86,9 +86,9 @@
 // - Apple devices
 #elif defined(__APPLE__)
 # if defined(__aarch64__)
-#  define DEFAULT_TARGET_NAME "aarch64-apple-macosx"
+#  define DEFAULT_TARGET_NAME "aarch64-apple-darwin"
 # else
-#  define DEFAULT_TARGET_NAME "x86_64-apple-macosx"
+#  define DEFAULT_TARGET_NAME "x86_64-apple-darwin"
 #endif
 // - Haiku
 #elif defined(__HAIKU__)


### PR DESCRIPTION
Here, two small patches that allows me to build rust on macOS 12.1 as
```
env OPENSSL_DIR=/opt/local/libexec/openssl11 ./build-1.54.0.sh
env RUSTC_VERSION=1.54.0 MRUSTC_TARGET_VER=1.54 OUTDIR_SUF=-1.54.0 make -C run_rustc all
```

