### PR TITLE
Fixed some warnings from `clang` (ref #236)

### DIFF
--- a/src/include/tagged_union.hpp
+++ b/src/include/tagged_union.hpp
@@ -208,7 +208,18 @@
  * ```
  */
 #define TAGGED_UNION(_name, _def, ...)  TU_EXP1( TAGGED_UNION_EX(_name, (), _def, (TU_EXP(__VA_ARGS__)), (), (), ()) )
+#if defined(__clang__)
 #define TAGGED_UNION_EX(_name, _inherit, _def, _variants, _extra_move, _extra_assign, _extra) \
+_Pragma("clang diagnostic push"); \
+_Pragma("clang diagnostic ignored \"-Wnon-c-typedef-for-linkage\""); \
+    _TAGGED_UNION_EX(_name, _inherit, _def, _variants, _extra_move, _extra_assign, _extra) \
+_Pragma("clang diagnostic pop");
+#else
+#define TAGGED_UNION_EX(_name, _inherit, _def, _variants, _extra_move, _extra_assign, _extra) \
+    _TAGGED_UNION_EX(_name, _inherit, _def, _variants, _extra_move, _extra_assign, _extra)
+#endif
+
+#define _TAGGED_UNION_EX(_name, _inherit, _def, _variants, _extra_move, _extra_assign, _extra) \
 class _name TU_EXP _inherit { \
     typedef _name self_t;/*
 */public:\


### PR DESCRIPTION
Here two fixes:
 - the correct suppression for clang's nitpicking
 - minor fixes for `typeid` side effect