### PR TITLE
Enforce `-mtune=core2` and `-mtune=yonah` on macOS

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -541,11 +541,21 @@ namespace
                 ARCH_X86_64
                 };
         }
+        else if(target_name == "i686-apple-darwin")
+        {
+            // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
+            // The first 32bit Intel Mac was Core Solo aka yonah. It allows to use `-march=yonah` like Rust.
+            return TargetSpec {
+                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {"-march=yonah"}, {}},
+                ARCH_X86_64
+                };
+        }
         else if(target_name == "x86_64-apple-darwin")
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
+            // The first 64bit Intel Mac was Core Duo. It allows to use `-march=core2` like Rust.
             return TargetSpec {
-                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {}, {}},
+                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {"-march=core2"}, {}},
                 ARCH_X86_64
                 };
         }


### PR DESCRIPTION
I've used the same cpu which is used by Rust: `core2` for x86_64[1] and `yonah` for i686[2]. I also used `mtine` instead of `mcpu` because it was deprecated at gcc since version 5[3].

It closes https://github.com/thepowersgang/mrustc/issues/214

I also added missed `i686-apple-darwin` target.

Footnotes:
[1]  https://github.com/rust-lang/rust/blob/1.54.0/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
[2]  https://github.com/rust-lang/rust/blob/1.54.0/compiler/rustc_target/src/spec/i686_apple_darwin.rs
[3]  https://github.com/gcc-mirror/gcc/commit/9d913bbf3fc996874649168d7d144a642012ac9b