### PR TITLE
Obtain crash from remote build

### DIFF
--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -1474,6 +1474,7 @@ bool spawn_process(const char* exe_name, const StringList& args, const StringLis
     {
         posix_spawn_file_actions_init(&fa);
         posix_spawn_file_actions_addopen(&fa, 1, logfile_str.c_str(), O_CREAT|O_WRONLY|O_TRUNC, 0644);
+        posix_spawn_file_actions_adddup2(&fa, 1, 2);
     }
 
     // Generate `argv`

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -1561,7 +1561,26 @@ bool spawn_process(const char* exe_name, const StringList& args, const StringLis
         for(const auto& p : argv)
             ::std::cerr  << " " << p;
         ::std::cerr << ::std::endl;
-        //::std::cerr << "See " << logfile << " for the compiler output" << ::std::endl;
+        if ( getenv("MINICARGO_DUMP_COMPILER_OUTPUT_ON_ERROR") ) {
+            ::std::ifstream in(logfile_str);
+            if (in.is_open())
+            {
+                ::std::cerr << "Compiler output starts here" << "---" << ::std::endl;
+                while (in.good())
+                {
+                    ::std::string line;
+                    ::std::getline(in, line);
+                    ::std::cerr << line <<  ::std::endl;
+                }
+                ::std::cerr << ::std::endl << "---" << ::std::endl;
+            }
+            else
+            {
+                ::std::cerr << "Unable to open file" << logfile << ::std::endl;
+            }
+        } else {
+            ::std::cerr << "See " << logfile << " for the compiler output" << ::std::endl;
+        }
         return false;
     }
     else

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -1303,6 +1303,10 @@ bool Builder::build_library(const PackageManifest& manifest, bool is_for_host, s
 bool Builder::spawn_process_mrustc(const StringList& args, StringListKV env, const ::helpers::path& logfile) const
 {
     //env.push_back("MRUSTC_DEBUG", "");
+    if( getenv("MRUSTC_DUMP_BACKTRACE") )
+    {
+        env.push_back("MRUSTC_DUMP_BACKTRACE", "1");
+    }
     auto rv = spawn_process(m_compiler_path.str().c_str(), args, env, logfile);
     if(getenv("MINICARGO_RUN_ONCE") || getenv("MINICARGO_RUN_ONCE"))
     {


### PR DESCRIPTION
This PR is depends on https://github.com/thepowersgang/mrustc/pull/248 and it was found by this one :)

Why? Let assume that I run CI as github action and at some point bootstrap fails like this `Process was terminated with signal 13`.

I haven't got access to a disk and can't read `_dbg.txt` file, nor see the crash report. 