### PR TITLE
Flush error stream before death

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -52,6 +52,8 @@ namespace {
         {
             sink << parent->filename << ":" << parent->start_line << ": note: From here" << ::std::endl;
         }
+
+        sink << ::std::flush;
     }
 }
 void Span::bug(::std::function<void(::std::ostream&)> msg) const


### PR DESCRIPTION
`exit()` or `abort()` never flushes the stream buffer that may lead to a crash without any explanation.