### PR TITLE
A few trivial fixes that allows build standalone_miri on macOS

### DIFF
--- a/tools/standalone_miri/miri_extern.cpp
+++ b/tools/standalone_miri/miri_extern.cpp
@@ -28,7 +28,7 @@
 #undef DEBUG
 
 
-#ifdef _WIN32
+#if _WIN32 || __APPLE__
 const char* memrchr(const void* p, int c, size_t s) {
     const char* p2 = reinterpret_cast<const char*>(p);
     while( s > 0 )

--- a/tools/standalone_miri/miri_extern.cpp
+++ b/tools/standalone_miri/miri_extern.cpp
@@ -623,7 +623,7 @@ bool InterpreterThread::call_extern(Value& rv, const ::std::string& link_name, c
     else if( link_name == "clock_gettime" )
     {
         // int clock_gettime(clockid_t clk_id, struct timespec *tp);
-        auto clk_id = args.at(0).read_u32(0);
+        auto clk_id = (clockid_t) args.at(0).read_u32(0);
         auto tp_vr = args.at(1).read_pointer_valref_mut(0, sizeof(struct timespec));
 
         LOG_DEBUG("clock_gettime(" << clk_id << ", " << tp_vr);


### PR DESCRIPTION
The fail:
```
[CXX] miri_extern.cpp
miri_extern.cpp:630:20: error: no matching function for call to 'clock_gettime'
        int rv_i = clock_gettime(clk_id, reinterpret_cast<struct timespec*>(tp_vr.data_ptr_mut()));
                   ^~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/time.h:178:5: note: candidate function not viable: no known conversion from 'unsigned int' to 'clockid_t' for 1st argument
int clock_gettime(clockid_t __clock_id, struct timespec *__tp);
    ^
miri_extern.cpp:749:27: error: use of undeclared identifier 'memrchr'; did you mean 'memchr'?
        const void* ret = memrchr(ptr, c, n);
                          ^~~~~~~
                          memchr
```