### PR TITLE
Use `F_DUPFD_CLOEXEC` only on macOS 10.7+

### DIFF
--- a/tools/standalone_miri/miri_extern.cpp
+++ b/tools/standalone_miri/miri_extern.cpp
@@ -426,7 +426,9 @@ bool InterpreterThread::call_extern(Value& rv, const ::std::string& link_name, c
         case F_GETFD: rv_i = fcntl_noarg("F_GETFD");    break;
         // - Integer arguments
         case F_DUPFD        : rv_i = fcntl_int("F_DUPFD"        );  break;
+#if !defined(__APPLE__) || __DARWIN_C_LEVEL >= 200809L
         case F_DUPFD_CLOEXEC: rv_i = fcntl_int("F_DUPFD_CLOEXEC");  break;
+#endif
         case F_SETFD        : rv_i = fcntl_int("F_SETFD"        ); break;
         default:
             if( args.size() > 2 )


### PR DESCRIPTION
`F_DUPFD_CLOEXEC` was introduced in macOS 10.7 like this:
```
#if __DARWIN_C_LEVEL >= 200809L
#define	F_DUPFD_CLOEXEC		67	/* mark the dup with FD_CLOEXEC */
#endif
```