### PR TITLE
Fix -Wmaybe-uninitialized warnings in move constructors

### DIFF
--- a/src/hir/type_ref.hpp
+++ b/src/hir/type_ref.hpp
@@ -7,6 +7,7 @@
 */
 #pragma once
 
+#include <utility>
 #include <rc_string.hpp>
 #include <span.hpp>
 
@@ -63,9 +64,8 @@ public:
     TypeRef();
     explicit TypeRef(const TypeRef& x);
     TypeRef(TypeRef&& x):
-        m_ptr(x.m_ptr)
+        m_ptr(::std::exchange(x.m_ptr, nullptr))
     {
-        x.m_ptr = nullptr;
     }
     ~TypeRef();
 

--- a/src/include/rc_string.hpp
+++ b/src/include/rc_string.hpp
@@ -9,6 +9,7 @@
 
 #include <cstring>
 #include <ostream>
+#include <utility>
 #include "../common.hpp"
 
 class RcString
@@ -47,9 +48,8 @@ public:
         if( m_ptr ) m_ptr->refcount += 1;
     }
     RcString(RcString&& x):
-        m_ptr(x.m_ptr)
+        m_ptr(::std::exchange(x.m_ptr, nullptr))
     {
-        x.m_ptr = nullptr;
     }
 
     ~RcString();

--- a/src/include/span.hpp
+++ b/src/include/span.hpp
@@ -10,6 +10,7 @@
 #include <rc_string.hpp>
 #include <functional>
 #include <memory>
+#include <utility>
 
 enum ErrorType
 {
@@ -45,9 +46,8 @@ public:
 
     Span(const Span& x);
     Span(Span&& x):
-        m_ptr(x.m_ptr)
+        m_ptr(::std::exchange(x.m_ptr, nullptr))
     {
-        x.m_ptr = nullptr;
     }
 
     Span& operator=(const Span& x)


### PR DESCRIPTION
With GCC 9, x.m_ptr was triggering -Wmaybe-uninitialized.
This seems to silence the warnings without changing the behavior.

(This is purely cosmetic, so feel free to close if you prefer the existing style. This warning can pop up in other spurious contexts so you may prefer to silence it entirely.)