### PR TITLE
Also allow system-provided llvm-config in run_rustc

### DIFF
--- a/run_rustc/Makefile
+++ b/run_rustc/Makefile
@@ -85,7 +85,7 @@ BINDIR := $(PREFIX)bin/
 LIBDIR := $(PREFIX)lib/rustlib/$(RUSTC_TARGET)/lib/
 CARGO_HOME := $(PREFIX)cargo_home/
 
-LLVM_CONFIG := $(RUST_SRC)build/bin/llvm-config
+LLVM_CONFIG ?= $(RUST_SRC)build/bin/llvm-config
 LLVM_TARGETS ?= X86;ARM;AArch64#;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX
 
 RUSTC_ENV_VARS := CFG_COMPILER_HOST_TRIPLE=$(RUSTC_TARGET)


### PR DESCRIPTION
Like b8ea12a041d37441bc8de48a110d0b0bd449a793, just in another place.