### PR TITLE
Removed side effect from typeid call (ref #236)

### DIFF
--- a/src/ast/expr.cpp
+++ b/src/ast/expr.cpp
@@ -21,6 +21,10 @@ ExprNodeP::ExprNodeP(std::unique_ptr<ExprNode> node)
     : m_ptr(node.release())
 {
 }
+const char* ExprNodeP::type_name() const
+{
+    return typeid(*m_ptr).name();
+}
 
 Expr::Expr(ExprNodeP node):
     m_node(node.release())

--- a/src/ast/expr.hpp
+++ b/src/ast/expr.hpp
@@ -736,8 +736,8 @@ class NodeVisitorDef:
 {
 public:
     inline void visit(ExprNodeP& cnode) {
-        if(cnode.get()) {
-            TRACE_FUNCTION_F(typeid(*cnode).name());
+        if(cnode.is_valid()) {
+            TRACE_FUNCTION_F(cnode.type_name());
             cnode->visit(*this);
         }
     }

--- a/src/ast/expr_ptr.hpp
+++ b/src/ast/expr_ptr.hpp
@@ -42,6 +42,8 @@ public:
 
     ExprNode* release() { auto rv = m_ptr; m_ptr = nullptr; return rv; }
     void reset(ExprNode* n = nullptr) { this->~ExprNodeP(); m_ptr = n; }
+
+    const char* type_name() const;
 };
 
 class Expr

--- a/src/expand/mod.cpp
+++ b/src/expand/mod.cpp
@@ -827,7 +827,7 @@ struct CExpandExpr:
                 ::AST::Pattern lower(::AST::ExprNodeP& ep) {
                     assert(ep);
                     ep->visit(*this);
-                    ASSERT_BUG(ep->span(), m_rv_set, typeid(*ep).name() << " - Didn't yield a pattern");
+                    ASSERT_BUG(ep->span(), m_rv_set, ep.type_name() << " - Didn't yield a pattern");
                     if(m_is_slot) {
                         assert(!m_slots.empty());
                         assert(!m_slots.back().second);

--- a/src/hir/expr.cpp
+++ b/src/hir/expr.cpp
@@ -11,6 +11,11 @@
 {
 }
 
+const char* ::HIR::ExprNode::type_name() const
+{
+    return typeid(*this).name();
+}
+
 #define DEF_VISIT(nt, n, code)   void ::HIR::nt::visit(ExprVisitor& nv) { nv.visit_node(*this); nv.visit(*this); } void ::HIR::ExprVisitorDef::visit(::HIR::nt& n) { code }
 
 void ::HIR::ExprVisitor::visit_node_ptr(::std::unique_ptr< ::HIR::ExprNode>& node_ptr) {
@@ -21,7 +26,7 @@ void ::HIR::ExprVisitor::visit_node(::HIR::ExprNode& node) {
 }
 void ::HIR::ExprVisitorDef::visit_node_ptr(::std::unique_ptr< ::HIR::ExprNode>& node_ptr) {
     assert(node_ptr);
-    TRACE_FUNCTION_F(&*node_ptr << " " << typeid(*node_ptr).name());
+    TRACE_FUNCTION_F(&*node_ptr << " " << node_ptr->type_name());
     node_ptr->visit(*this);
     visit_type(node_ptr->m_res_type);
 }

--- a/src/hir/expr.hpp
+++ b/src/hir/expr.hpp
@@ -60,6 +60,8 @@ public:
         m_span( mv$(sp) )
     {}
     virtual ~ExprNode();
+
+    const char* type_name() const;
 };
 
 typedef ::std::unique_ptr<ExprNode> ExprNodeP;

--- a/src/hir/from_ast_expr.cpp
+++ b/src/hir/from_ast_expr.cpp
@@ -23,7 +23,7 @@ struct LowerHIR_ExprNode_Visitor:
     ::std::unique_ptr< ::HIR::ExprNode> lower(::AST::ExprNodeP& ep) {
         assert(ep);
         ep->visit(*this);
-        ASSERT_BUG(ep->span(), m_rv, typeid(*ep).name() << " - Yielded a nullptr HIR node");
+        ASSERT_BUG(ep->span(), m_rv, ep.type_name() << " - Yielded a nullptr HIR node");
         return std::move(m_rv);
     }
     ::std::unique_ptr< ::HIR::ExprNode> lower_opt(::AST::ExprNodeP& ep) {

--- a/src/hir_typeck/expr_cs.cpp
+++ b/src/hir_typeck/expr_cs.cpp
@@ -7422,7 +7422,7 @@ void Typecheck_Code_CS(const typeck::ModuleState& ms, t_args& args, const ::HIR:
         }
         BUG(root_ptr->span(), "Spare rules left after typecheck stabilised");
     }
-    DEBUG("root_ptr = " << typeid(*root_ptr).name() << " " << root_ptr->m_res_type);
+    DEBUG("root_ptr = " << root_ptr->type_name() << " " << root_ptr->m_res_type);
 
     // - Recreate the pointer
     expr.reset( root_ptr.release() );

--- a/src/hir_typeck/expr_cs__enum.cpp
+++ b/src/hir_typeck/expr_cs__enum.cpp
@@ -2140,6 +2140,6 @@ void Typecheck_Code_CS__EnumerateRules(
     context.add_ivars(root_ptr->m_res_type);
     root_ptr->visit(visitor);
 
-    DEBUG("Return type = " << new_res_ty << ", root_ptr = " << typeid(*root_ptr).name() << " " << root_ptr->m_res_type);
+    DEBUG("Return type = " << new_res_ty << ", root_ptr = " << root_ptr->type_name() << " " << root_ptr->m_res_type);
     context.equate_types_coerce(sp, new_res_ty, root_ptr);
 }


### PR DESCRIPTION
Can build it now with `-Werror=potentially-evaluated-expression`