### PR TITLE
Add a default virtual destructor to `Monomorphiser` (ref #236)

### DIFF
--- a/src/hir_typeck/monomorph.hpp
+++ b/src/hir_typeck/monomorph.hpp
@@ -15,6 +15,7 @@ extern bool monomorphise_type_needed(const ::HIR::TypeRef& tpl);
 class Monomorphiser
 {
 public:
+    virtual ~Monomorphiser() = default;
     virtual ::HIR::TypeRef get_type(const Span& sp, const ::HIR::GenericRef& g) const = 0;
     virtual ::HIR::ConstGeneric get_value(const Span& sp, const ::HIR::GenericRef& g) const = 0;
 


### PR DESCRIPTION
Can compile it with `-Werror=delete-abstract-non-virtual-dtor`, and after that make full bootstrap of rustc.