### PR TITLE
Remove unknown flag for gcc12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CPPFLAGS += -I tools/common/
 CXXFLAGS += -Wno-pessimizing-move
 CXXFLAGS += -Wno-misleading-indentation
 #CXXFLAGS += -Wno-unused-private-field
-CXXFLAGS += -Wno-unknown-warning-option
+#CXXFLAGS += -Wno-unknown-warning-option
 
 CXXFLAGS += -Werror=return-type
 


### PR DESCRIPTION
It fails as:
```
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
```