### PR TITLE
Compatibility with macOS 10.7

### DIFF
--- a/src/parse/lex.cpp
+++ b/src/parse/lex.cpp
@@ -1102,7 +1102,7 @@ uint32_t Lexer::parseEscape(char enclosing)
 char Lexer::getc_byte()
 {
     int rv = m_istream.get();
-    if( rv == EOF || m_istream.eof() )
+    if( rv == EOF )
         throw Lexer::EndOfFile();
 
     if( rv == '\r' )

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -761,7 +761,7 @@ namespace {
                     return t;
                 }
                 ::std::string get_token_int() {
-                    if( ifp.eof() )
+                    if( ifp.eof() && m_c == '\0')
                         return "";
                     while( m_c == ' ' )
                     {


### PR DESCRIPTION
Let assume that `::std::istream` marks itself as reached `EOF` after reading the last character from file which is `':'` in case of minicargo's `build.cpp`.

This leads to missing `':'` because the next call of `get_token_int()` returns `""` because `ifp.eof()` is `true`, instead of returning `":"` as it should.

This missed `':'` leads to assert that dependency file aren't well formatted on some wired system.

The same happened with `Lexer::getc_byte` when `m_istream.get()` returns not `EOF` but marks stream as reached `EOF` that means the next read returns `EOF`.

Thus, this fixes: https://github.com/thepowersgang/mrustc/issues/284