### PR TITLE
Introducing `MRUSTC_LIB` env variable (ref #214)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -893,6 +893,11 @@ ProgramParams::ProgramParams(int argc, char *argv[])
         this->lib_search_dirs.push_back(a);
     }
 
+    if( const auto* a = getenv("MRUSTC_LIBD") )
+    {
+        this->libraries.push_back(a);
+    }
+
     // Hacky command-line parsing
     for( int i = 1; i < argc; i ++ )
     {


### PR DESCRIPTION
The idea is simple: we need some way to put `-latomic` to `gcc` call. Let add a dedicated variable which allows to add any library which may be needed.

It fixes: https://github.com/thepowersgang/mrustc/pull/214