### PR TITLE
minicargo - fix argument quoting on Windows

### DIFF
--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -1376,6 +1376,56 @@ const helpers::path& get_mrustc_path()
     return s_compiler_path;
 }
 
+#ifdef _WIN32
+// Escapes an argument for CommandLineToArgv on Windows
+void argv_quote_windows(const std::string& arg, std::stringstream& cmdline)
+{
+    if (arg.empty()) return;
+    // Add a space to start a new argument.
+    cmdline << " ";
+
+    // Don't quote unless we need to
+    if (arg.find_first_of(" \t\n\v\"") == arg.npos)
+    {
+        cmdline << arg;
+        return;
+    }
+    else
+    {
+        cmdline << '"';
+        for (auto ch = arg.begin(); ; ++ch) {
+            size_t backslash_count = 0;
+
+            // Count backslashes
+            while (ch != arg.end() && *ch == L'\\') {
+                ++ch;
+                ++backslash_count;
+            }
+
+            if (ch == arg.end()) {
+                // Escape backslashes, but let the terminating
+                // double quotation mark we add below be interpreted
+                // as a metacharacter.
+                for (int i = 0; i < backslash_count * 2; i++) cmdline << '\\';
+                break;
+            }
+            else if (*ch == L'"')
+            {
+                // Escape backslashes and the following double quotation mark.
+                for (int i = 0; i < backslash_count * 2 + 1; i++) cmdline << '\\';
+                cmdline << *ch;
+            }
+            else
+            {
+                for (int i = 0; i < backslash_count; i++) cmdline << '\\';
+                cmdline << *ch;
+            }
+        }
+        cmdline << '"';
+    }
+}
+#endif
+
 bool spawn_process(const char* exe_name, const StringList& args, const StringListKV& env, const ::helpers::path& logfile, const ::helpers::path& working_directory/*={}*/)
 {
     if( getenv("MINICARGO_DUMPENV") )
@@ -1397,8 +1447,7 @@ bool spawn_process(const char* exe_name, const StringList& args, const StringLis
     ::std::stringstream cmdline;
     cmdline << exe_name;
     for (const auto& arg : args.get_vec())
-        // TODO: Escaping rules (quote if spaces, `^` before interior quotes or `^`)
-        cmdline << " " << arg;
+        argv_quote_windows(arg, cmdline);
     auto cmdline_str = cmdline.str();
     if(true)
     {


### PR DESCRIPTION
Adds argument escaping in minicargo for Windows based on the approach described here:

https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way