### PR TITLE
Windows build - fix compilation errors on VS2022

### DIFF
--- a/src/include/tagged_union.hpp
+++ b/src/include/tagged_union.hpp
@@ -18,6 +18,7 @@
 //#include "cpp_unpack.h"
 #include <cassert>
 #include <string>
+#include <stdexcept>
 
 #define TU_FIRST(a, ...)    a
 #define TU_EXP1(x)  x

--- a/src/mir/from_hir_match.cpp
+++ b/src/mir/from_hir_match.cpp
@@ -2323,7 +2323,7 @@ void MIR_LowerHIR_Match_Simple( MirBuilder& builder, MirConverter& conv, ::HIR::
 
 int MIR_LowerHIR_Match_Simple__GeneratePattern(MirBuilder& builder, const Span& sp, const PatternRule* rules, unsigned int num_rules, const ::HIR::TypeRef& top_ty, const ::MIR::LValue& top_val, unsigned int field_path_ofs,  ::MIR::BasicBlockId fail_bb)
 {
-    TRACE_FUNCTION_F("top_ty = " << top_ty << ", rules = [" << FMT_CB(os, for(const auto* r = rules; r != rules+num_rules; r++) os << *r << ","; ));
+    TRACE_FUNCTION_F("top_ty = " << top_ty << ", rules = [" << FMT_CB(os, for(auto i = 0; i < num_rules; i++) os << rules[i] << ","; ));
     for(unsigned int rule_idx = 0; rule_idx < num_rules; rule_idx ++)
     {
         const auto& rule = rules[rule_idx];

--- a/tools/backend_c/backend_c.cpp
+++ b/tools/backend_c/backend_c.cpp
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[])
                 rv = get_ord(t2, t1);
                 return rv == OrdGreater;
             }
-            bool operator()(const HIR::TypeRef& t1, const HIR::TypeRef& t2) {
+            bool operator()(const HIR::TypeRef& t1, const HIR::TypeRef& t2) const {
                 return t1 < t2;
             }
         };


### PR DESCRIPTION
A few minor changes necessary to make `mrustc` build with VS2022.

Does not actually change any of the projects to build with VS2022.