### PR TITLE
Fix targets for Darwin PowerPC

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -59,6 +59,12 @@ const TargetArch ARCH_POWERPC64 = {
     { /*atomic(u8)=*/true, true, true, true,  true },
     TargetArch::Alignments(2, 4, 8, 16, 4, 8, 8)
 };
+const TargetArch ARCH_POWERPC32 = {
+    "powerpc",
+    32, true,
+    { /*atomic(u8)=*/true, false, true, false,  true },
+    TargetArch::Alignments(2, 4, 8, 16, 4, 8, 4)
+};
 const TargetArch ARCH_POWERPC64LE = {
     "powerpc64",
     64, false,
@@ -591,6 +597,22 @@ namespace
             return TargetSpec {
                 "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "aarch64-apple-darwin", {}, {}},
                 ARCH_ARM64
+                };
+        }
+        else if(target_name == "powerpc-apple-darwin")
+        {
+            // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
+            return TargetSpec {
+                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "powerpc-apple-darwin", {}, {}},
+                ARCH_POWERPC32
+                };
+        }
+        else if(target_name == "powerpc64-apple-darwin")
+        {
+            // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
+            return TargetSpec {
+                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "powerpc64-apple-darwin", {}, {}},
+                ARCH_POWERPC64
                 };
         }
         else if(target_name == "arm-unknown-haiku")

--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -93,6 +93,10 @@
 #elif defined(__APPLE__)
 # if defined(__aarch64__)
 #  define DEFAULT_TARGET_NAME "aarch64-apple-darwin"
+# elif defined(__ppc64__)
+#  define DEFAULT_TARGET_NAME "powerpc64-apple-darwin"
+# elif defined(__ppc__)
+#  define DEFAULT_TARGET_NAME "powerpc-apple-darwin"
 # else
 #  define DEFAULT_TARGET_NAME "x86_64-apple-darwin"
 #endif


### PR DESCRIPTION
See: https://github.com/thepowersgang/mrustc/issues/300#issuecomment-1506104456

@thepowersgang Could you please check this?

P. S. As I mention in the topic, Darwin on ppc32 _may_ need 4-byte bools, since Apple ABI defines that: http://personal.denison.edu/~bressoud/cs281-s07/MacOSXLowLevelABI.pdf
Not sure if that should apply to Rust code though.