### PR TITLE
Add missing includes for GCC >= 13, Clang

### DIFF
--- a/src/hir/type.cpp
+++ b/src/hir/type.cpp
@@ -8,6 +8,7 @@
 #include "type.hpp"
 #include <span.hpp>
 #include "expr.hpp" // Hack for cloning array types
+#include <cstdint>
 
 namespace HIR {
 

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -13,6 +13,7 @@
 #include <hir/type.hpp>
 #include "../hir/asm.hpp"
 #include <int128.h>
+#include <cstdint>
 
 struct MonomorphState;
 

--- a/tools/common/toml.h
+++ b/tools/common/toml.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 class TomlFileIter;
 struct TomlKeyValue;


### PR DESCRIPTION
Just one of some patches needed to ensure Rust builds with newer GCC and Clang, the other patches involve modifying the rust source code itself.