### PR TITLE
1.29.0: patch <limits> into LLVM to fix GCC 12 compilation

### DIFF
--- a/rustc-1.29.0-src.patch
+++ b/rustc-1.29.0-src.patch
@@ -268,4 +268,12 @@ index e0fa576..c99775d 100644
 +        assert_eq!(<CFAttributedString as TCFType>::type_id(), <CFMutableAttributedString as TCFType>::type_id());
 +    }
 +}
-
+--- src/llvm/lib/Demangle/ItaniumDemangle.cpp
++++ src/llvm/lib/Demangle/ItaniumDemangle.cpp
+@@ -19,6 +19,7 @@
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cstring>
++#include <limits>
+ #include <numeric>
+ #include <vector>


### PR DESCRIPTION
Fixes building with GCC 12.x. The issue is the missing `<limits>` header in `llvm/lib/Demangle/ItaniumDemangle.cpp`.
In current LLVM, the <limits> header is included via `<ItaniumDemangle.h>, added in https://github.com/llvm/llvm-project/commit/1f9e18b6565fd1bb69c4b649b9efd3467b3c7c7d, however that header doesn't exist in the LLVM revision (looks like 7.0.0 ?) used here.

This was also reported in #293. To reproduce:
```bash
apt install gcc g++ git make patch libz-dev curl cmake python3

g++ --version
g++ (Ubuntu 12.3.0-3ubuntu1) 12.3.0

git clone https://github.com/thepowersgang/mrustc

cd mrustc

make RUSTCSRC

make -f minicargo.mk
make -f Makefile all
make[1]: Entering directory '/mrustc'
[CXX] -o .obj/main.o
[CXX] -o .obj/span.o
[CXX] -o .obj/rc_string.o
[CXX] -o .obj/debug.o
-- Generating done (0.6s)
-- Build files have been written to: /mrustc/rustc-1.29.0-src/build
cd rustc-1.29.0-src/build && make -j 1
make[1]: Entering directory '/mrustc/rustc-1.29.0-src/build'
…
make[3]: Entering directory '/mrustc/rustc-1.29.0-src/build'
[  0%] Building CXX object lib/Demangle/CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:176:36: error: 'numeric_limits' is not a member of 'std'
  176 |   unsigned CurrentPackIndex = std::numeric_limits<unsigned>::max();
      |                                    ^~~~~~~~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:176:51: error: expected primary-expression before 'unsigned'
  176 |   unsigned CurrentPackIndex = std::numeric_limits<unsigned>::max();
      |                                                   ^~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:177:34: error: 'numeric_limits' is not a member of 'std'
  177 |   unsigned CurrentPackMax = std::numeric_limits<unsigned>::max();
      |                                  ^~~~~~~~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:177:49: error: expected primary-expression before 'unsigned'
  177 |   unsigned CurrentPackMax = std::numeric_limits<unsigned>::max();
      |                                                 ^~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp: In member function 'void {anonymous}::ParameterPack::initializePackExpansion({anonymous}::OutputStream&) const':
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:1067:34: error: 'numeric_limits' is not a member of 'std'
 1067 |     if (S.CurrentPackMax == std::numeric_limits<unsigned>::max()) {
      |                                  ^~~~~~~~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:1067:49: error: expected primary-expression before 'unsigned'
 1067 |     if (S.CurrentPackMax == std::numeric_limits<unsigned>::max()) {
      |                                                 ^~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:1067:49: error: expected ')' before 'unsigned'
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:1067:8: note: to match this '('
 1067 |     if (S.CurrentPackMax == std::numeric_limits<unsigned>::max()) {
      |        ^
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp: In member function 'virtual void {anonymous}::ParameterPackExpansion::printLeft({anonymous}::OutputStream&) const':
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:1150:35: error: 'numeric_limits' is not a member of 'std'
 1150 |     constexpr unsigned Max = std::numeric_limits<unsigned>::max();
      |                                   ^~~~~~~~~~~~~~
/mrustc/rustc-1.29.0-src/src/llvm/lib/Demangle/ItaniumDemangle.cpp:1150:50: error: expected primary-expression before 'unsigned'
 1150 |     constexpr unsigned Max = std::numeric_limits<unsigned>::max();
      |                                                  ^~~~~~~~
make[3]: *** [lib/Demangle/CMakeFiles/LLVMDemangle.dir/build.make:76: lib/Demangle/CMakeFiles/LLVMDemangle.dir/ItaniumDemangle.cpp.o] Error 1
```