### PR TITLE
doc: add python3 to deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Dependencies
 - `libz-dev` (used to reduce size of bytecode files, linux only - windows uses vcpkg to download it)
 - `curl` (for downloading the rust source, linux only)
 - `cmake` (at least 3.4.3, required for building llvm in rustc)
+- `python3` (required for building llvm in rustc)
 
 Linux GNU and macOS
 -----


### PR DESCRIPTION
This is required to build llvm in rustc. i.e without:
```bash
apt install gcc g++ git make patch libz-dev curl cmake

git clone https://github.com/thepowersgang/mrustc

cd mrustc

RUSTC_VERSION=1.54.0 make RUSTCSRC

RUSTC_VERSION=1.54.0 make -f minicargo.mk
make -f Makefile all
make[1]: Entering directory '/mrustc'
[CXX] -o .obj/main.o
...
-- OCaml bindings disabled.
-- LLVM host triple: x86_64-unknown-linux-gnu
-- LLVM default target triple: x86_64-unknown-linux-gnu
-- Building with -fPIC
CMake Error at /usr/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Python3 (missing: Python3_EXECUTABLE Interpreter)
Call Stack (most recent call first):
  /usr/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.26/Modules/FindPython/Support.cmake:3761 (find_package_handle_standard_args)
  /usr/share/cmake-3.26/Modules/FindPython3.cmake:551 (include)
  CMakeLists.txt:700 (find_package)

-- Configuring incomplete, errors occurred!
make: *** [minicargo.mk:255: rustc-1.54.0-src/build/Makefile] Error 1
```