### PR TITLE
rustc: regenerate patches for 1.29.0 & 1.54.0

### DIFF
--- a/rustc-1.19.0-src.patch
+++ b/rustc-1.19.0-src.patch
@@ -1,6 +1,7 @@
 --- src/libcore/intrinsics.rs
 +++ src/libcore/intrinsics.rs
-@@ -678,5 +678,9 @@
+@@ -691,6 +691,10 @@ extern "rust-intrinsic" {
+     pub fn size_of_val<T: ?Sized>(_: &T) -> usize;
      pub fn min_align_of_val<T: ?Sized>(_: &T) -> usize;
  
 +    /// Obtain the length of a slice pointer
@@ -9,10 +10,11 @@
 +
      /// Gets a static string slice containing the name of a type.
      pub fn type_name<T: ?Sized>() -> &'static str;
-
+ 
 --- src/libcore/slice/mod.rs
 +++ src/libcore/slice/mod.rs
-@@ -413,6 +413,8 @@
+@@ -412,9 +412,11 @@ impl<T> SliceExt for [T] {
+ 
      #[inline]
      fn len(&self) -> usize {
 -        unsafe {
@@ -24,3 +26,5 @@
 +        let rv = unsafe { ::intrinsics::mrustc_slice_len(self) };
 +        rv
      }
+ 
+     #[inline]

--- a/rustc-1.29.0-src.patch
+++ b/rustc-1.29.0-src.patch
@@ -1,7 +1,8 @@
 # Add mrustc slice length intrinsics
 --- src/libcore/intrinsics.rs
 +++ src/libcore/intrinsics.rs
-@@ -678,5 +678,9 @@
+@@ -689,6 +689,10 @@ extern "rust-intrinsic" {
+     pub fn size_of_val<T: ?Sized>(_: &T) -> usize;
      pub fn min_align_of_val<T: ?Sized>(_: &T) -> usize;
  
 +    /// Obtain the length of a slice pointer
@@ -13,7 +14,9 @@
 
 --- src/libcore/slice/mod.rs
 +++ src/libcore/slice/mod.rs
-@@ -413,5 +413,7 @@
+@@ -128,9 +128,11 @@ impl<T> [T] {
+     #[inline]
+     #[rustc_const_unstable(feature = "const_slice_len")]
      pub const fn len(&self) -> usize {
 -        unsafe {
 -            Repr { rust: self }.raw.len
@@ -24,65 +27,9 @@
 +        const fn len_inner<T>(s: &[T]) -> usize { unsafe { ::intrinsics::mrustc_slice_len(s) } }
 +        len_inner(self)
      }
-# Static-link rustc_codegen_llvm because mrustc doesn't have dylib support
---- src/librustc_driver/Cargo.toml
-+++ src/librustc_driver/Cargo.toml
-@@ -39,1 +39,2 @@
- syntax_pos = { path = "../libsyntax_pos" }
-+rustc_codegen_llvm = { path = "../librustc_codegen_llvm" }
---- src/librustc_driver/lib.rs
-+++ src/librustc_driver/lib.rs
-@@ -63,2 +63,3 @@
- extern crate syntax_pos;
-+extern crate rustc_codegen_llvm;
  
-@@ -296,3 +296,7 @@
-     }
- 
-+    if backend_name == "llvm" {
-+        return rustc_codegen_llvm::__rustc_codegen_backend;
-+    }
-+
-     let target = session::config::host_triple();
-# No workspace support in minicargo, patch cargo's Cargo.toml
---- src/tools/cargo/Cargo.toml
-+++ src/tools/cargo/Cargo.toml
-@@ -60,5 +60,5 @@
- # A noop dependency that changes in the Rust repository, it's a bit of a hack.
- # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
- # for more information.
--rustc-workspace-hack = "1.0.0"
-+rustc-workspace-hack = { path = "../rustc-workspace-hack" }
- 
-# mrustc can't represent a 24 byte version of this enum (no way of storing the
-# tag in padding)
---- src/librustc/ty/context.rs
-+++ src/librustc/ty/context.rs
-@@ -805,5 +805,5 @@
-         // Ensure our type representation does not grow
--        #[cfg(target_pointer_width = "64")]
--        assert!(mem::size_of::<ty::TypeVariants>() <= 24);
--        #[cfg(target_pointer_width = "64")]
--        assert!(mem::size_of::<ty::TyS>() <= 32);
-+        //#[cfg(target_pointer_width = "64")]
-+        //assert!(mem::size_of::<ty::TypeVariants>() <= 24);
-+        //#[cfg(target_pointer_width = "64")]
-+        //assert!(mem::size_of::<ty::TyS>() <= 32);
+     /// Returns `true` if the slice has a length of 0.
 
---- src/stdsimd/stdsimd/arch/detect/os/x86.rs
-+++ src/stdsimd/stdsimd/arch/detect/os/x86.rs
-@@ -14,5 +14,11 @@
- /// Performs run-time feature detection.
- #[inline]
-+#[cfg(not(rust_compiler="mrustc"))]
- pub fn check_for(x: Feature) -> bool {
-     cache::test(x as u32, detect_features)
- }
-+#[inline]
-+#[cfg(rust_compiler="mrustc")]
-+pub fn check_for(x: Feature) -> bool {
-+    false
-+}
 # macOS on Apple Silicon support
 --- src/liblibc/src/unix/bsd/apple/mod.rs
 +++ src/liblibc/src/unix/bsd/apple/mod.rs
@@ -163,6 +110,127 @@
      #[cfg_attr(target_os = "freebsd", link_name = "lstat@FBSD_1.0")]
      pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
 
+# mrustc can't represent a 24 byte version of this enum (no way of storing the
+# tag in padding)
+--- src/librustc/ty/context.rs
++++ src/librustc/ty/context.rs
+@@ -802,10 +802,10 @@ impl<'a, 'gcx> HashStable<StableHashingContext<'a>> for TypeckTables<'gcx> {
+ impl<'tcx> CommonTypes<'tcx> {
+     fn new(interners: &CtxtInterners<'tcx>) -> CommonTypes<'tcx> {
+         // Ensure our type representation does not grow
+-        #[cfg(target_pointer_width = "64")]
+-        assert!(mem::size_of::<ty::TypeVariants>() <= 24);
+-        #[cfg(target_pointer_width = "64")]
+-        assert!(mem::size_of::<ty::TyS>() <= 32);
++        //#[cfg(target_pointer_width = "64")]
++        //assert!(mem::size_of::<ty::TypeVariants>() <= 24);
++        //#[cfg(target_pointer_width = "64")]
++        //assert!(mem::size_of::<ty::TyS>() <= 32);
+ 
+         let mk = |sty| CtxtInterners::intern_ty(interners, interners, sty);
+         let mk_region = |r| {
+
+# Static-link rustc_codegen_llvm because mrustc doesn't have dylib support
+--- src/librustc_driver/Cargo.toml
++++ src/librustc_driver/Cargo.toml
+@@ -37,3 +37,4 @@ serialize = { path = "../libserialize" }
+ syntax = { path = "../libsyntax" }
+ syntax_ext = { path = "../libsyntax_ext" }
+ syntax_pos = { path = "../libsyntax_pos" }
++rustc_codegen_llvm = { path = "../librustc_codegen_llvm" }
+
+--- src/librustc_driver/lib.rs
++++ src/librustc_driver/lib.rs
+@@ -61,6 +61,7 @@ extern crate log;
+ extern crate syntax;
+ extern crate syntax_ext;
+ extern crate syntax_pos;
++extern crate rustc_codegen_llvm;
+ 
+ use driver::CompileController;
+ use pretty::{PpMode, UserIdentifiedItem};
+@@ -294,6 +295,10 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
+         return rustc_codegen_utils::codegen_backend::MetadataOnlyCodegenBackend::new
+     }
+ 
++    if backend_name == "llvm" {
++        return rustc_codegen_llvm::__rustc_codegen_backend;
++    }
++
+     let target = session::config::host_triple();
+     let mut sysroot_candidates = vec![filesearch::get_or_default_sysroot()];
+     let path = current_dll_path()
+
+--- src/stdsimd/stdsimd/arch/detect/os/x86.rs
++++ src/stdsimd/stdsimd/arch/detect/os/x86.rs
+@@ -13,9 +13,15 @@ use arch::detect::bit;
+ 
+ /// Performs run-time feature detection.
+ #[inline]
++#[cfg(not(rust_compiler="mrustc"))]
+ pub fn check_for(x: Feature) -> bool {
+     cache::test(x as u32, detect_features)
+ }
++#[inline]
++#[cfg(rust_compiler="mrustc")]
++pub fn check_for(x: Feature) -> bool {
++    false
++}
+ 
+ /// Run-time feature detection on x86 works by using the CPUID instruction.
+ ///
+
+# No workspace support in minicargo, patch cargo's Cargo.toml
+--- src/tools/cargo/Cargo.toml
++++ src/tools/cargo/Cargo.toml
+@@ -60,7 +60,7 @@ openssl = { version = '0.10.11', optional = true }
+ # A noop dependency that changes in the Rust repository, it's a bit of a hack.
+ # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
+ # for more information.
+-rustc-workspace-hack = "1.0.0"
++rustc-workspace-hack = { path = "../rustc-workspace-hack" }
+ 
+ [target.'cfg(target_os = "macos")'.dependencies]
+ core-foundation = { version = "0.6.0", features = ["mac_os_10_7_support"] }
+
+--- src/vendor/core-foundation-sys/src/attributed_string.rs
++++ src/vendor/core-foundation-sys/src/attributed_string.rs
+@@ -52,5 +52,4 @@ extern {
+         value: CFTypeRef,
+     );
+ 
+-    pub fn CFMutableAttributedStringGetTypeID() -> CFTypeID;
+ }
+
+# Backport of https://github.com/servo/core-foundation-rs/commit/aa6d1cd4c15561b48c24322527e3d9e60f603db4
+--- src/vendor/core-foundation/src/attributed_string.rs
++++ src/vendor/core-foundation/src/attributed_string.rs
+@@ -41,7 +41,7 @@ impl CFAttributedString {
+ declare_TCFType!{
+     CFMutableAttributedString, CFMutableAttributedStringRef
+ }
+-impl_TCFType!(CFMutableAttributedString, CFMutableAttributedStringRef, CFMutableAttributedStringGetTypeID);
++impl_TCFType!(CFMutableAttributedString, CFMutableAttributedStringRef, CFAttributedStringGetTypeID);
+ 
+ impl CFMutableAttributedString {
+     #[inline]
+@@ -77,3 +77,15 @@ impl CFMutableAttributedString {
+         }
+     }
+ }
++
++#[cfg(test)]
++mod tests {
++    use super::*;
++
++    #[test]
++    fn attributed_string_type_id_comparison() {
++        // CFMutableAttributedString TypeID must be equal to CFAttributedString TypeID.
++        // Compilation must not fail.
++        assert_eq!(<CFAttributedString as TCFType>::type_id(), <CFMutableAttributedString as TCFType>::type_id());
++    }
++}
+
 --- src/vendor/libc/src/unix/bsd/apple/mod.rs
 +++ src/vendor/libc/src/unix/bsd/apple/mod.rs
 @@ -2376,9 +2376,9 @@ extern {
@@ -229,45 +297,7 @@
      #[cfg_attr(target_os = "netbsd", link_name = "__lstat50")]
      #[cfg_attr(target_os = "freebsd", link_name = "lstat@FBSD_1.0")]
      pub fn lstat(path: *const c_char, buf: *mut stat) -> ::c_int;
-# Backport of https://github.com/servo/core-foundation-rs/commit/aa6d1cd4c15561b48c24322527e3d9e60f603db4
---- src/vendor/core-foundation-sys/src/attributed_string.rs
-+++ src/vendor/core-foundation-sys/src/attributed_string.rs
-@@ -52,5 +52,4 @@ extern {
-         value: CFTypeRef,
-     );
- 
--    pub fn CFMutableAttributedStringGetTypeID() -> CFTypeID;
- }
-diff --git a/core-foundation/src/attributed_string.rs b/core-foundation/src/attributed_string.rs
-index e0fa576..c99775d 100644
---- src/vendor/core-foundation/src/attributed_string.rs
-+++ src/vendor/core-foundation/src/attributed_string.rs
-@@ -41,7 +41,7 @@ impl CFAttributedString {
- declare_TCFType!{
-     CFMutableAttributedString, CFMutableAttributedStringRef
- }
--impl_TCFType!(CFMutableAttributedString, CFMutableAttributedStringRef, CFMutableAttributedStringGetTypeID);
-+impl_TCFType!(CFMutableAttributedString, CFMutableAttributedStringRef, CFAttributedStringGetTypeID);
- 
- impl CFMutableAttributedString {
-     #[inline]
-@@ -83,3 +83,16 @@ impl Default for CFMutableAttributedString {
-         Self::new()
-     }
- }
-+
-+
-+#[cfg(test)]
-+mod tests {
-+    use super::*;
-+
-+    #[test]
-+    fn attributed_string_type_id_comparison() {
-+        // CFMutableAttributedString TypeID must be equal to CFAttributedString TypeID.
-+        // Compilation must not fail.
-+        assert_eq!(<CFAttributedString as TCFType>::type_id(), <CFMutableAttributedString as TCFType>::type_id());
-+    }
-+}
+
 --- src/llvm/lib/Demangle/ItaniumDemangle.cpp
 +++ src/llvm/lib/Demangle/ItaniumDemangle.cpp
 @@ -19,6 +19,7 @@

--- a/rustc-1.39.0-src.patch
+++ b/rustc-1.39.0-src.patch
@@ -1,7 +1,8 @@
 # Add mrustc slice length intrinsics
 --- src/libcore/intrinsics.rs
 +++ src/libcore/intrinsics.rs
-@@ -685,4 +685,8 @@
+@@ -684,6 +684,10 @@ extern "rust-intrinsic" {
+     pub fn size_of_val<T: ?Sized>(_: &T) -> usize;
      pub fn min_align_of_val<T: ?Sized>(_: &T) -> usize;
  
 +    /// Obtain the length of a slice pointer
@@ -10,9 +11,12 @@
 +
      /// Gets a static string slice containing the name of a type.
      pub fn type_name<T: ?Sized>() -> &'static str;
+ 
 --- src/libcore/slice/mod.rs
 +++ src/libcore/slice/mod.rs
-@@ -68,5 +68,8 @@
+@@ -66,9 +66,12 @@ impl<T> [T] {
+     // SAFETY: const sound because we transmute out the length field as a usize (which it must be)
+     #[cfg_attr(not(bootstrap), allow_internal_unstable(const_fn_union))]
      pub const fn len(&self) -> usize {
 -        unsafe {
 -            crate::ptr::Repr { rust: self }.raw.len
@@ -24,48 +28,25 @@
 +        const fn len_inner<T>(s: &[T]) -> usize { unsafe { crate::intrinsics::mrustc_slice_len(s) } }
 +        len_inner(self)
      }
+ 
+     /// Returns `true` if the slice has a length of 0.
+
 #
 # Static-link rustc_codegen_llvm so the generated rustc is standalone
 # > Note: Interacts with `rustc-1.39.0-overrides.toml`
 #
 --- src/librustc_interface/util.rs
 +++ src/librustc_interface/util.rs
-@@ -421,2 +421,4 @@
+@@ -417,6 +417,8 @@ fn sysroot_candidates() -> Vec<PathBuf> {
+ }
+ 
  pub fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
 +    #[cfg(rust_compiler="mrustc")]
 +    { if(backend_name == "llvm") { extern "Rust" { fn __rustc_codegen_backend() -> Box<dyn CodegenBackend>; } return || unsafe { __rustc_codegen_backend() } } }
      // For now we only allow this function to be called once as it'll dlopen a
-# Disable most architecture intrinsics
---- src/stdarch/crates/std_detect/src/detect/mod.rs
-+++ src/stdarch/crates/std_detect/src/detect/mod.rs
-@@ -74,4 +74,7 @@
-         // this run-time detection logic is never called.
-         #[path = "os/other.rs"]
-         mod os;
-+    } else if #[cfg(rust_compiler="mrustc")] {
-+        #[path = "os/other.rs"]
-+        mod os;
-     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
---- vendor/ppv-lite86/src/lib.rs
-+++ vendor/ppv-lite86/src/lib.rs
-@@ -12,9 +12,9 @@
--#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
-+#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler="mrustc")))]
- pub mod x86_64;
--#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
-+#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler="mrustc")))]
- use self::x86_64 as arch;
+     // few things, which seems to work best if we only do that once. In
+     // general this assertion never trips due to the once guard in `get_codegen_backend`,
 
--#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
-+#[cfg(any(miri, rust_compiler="mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
- pub mod generic;
--#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
-+#[cfg(any(miri, rust_compiler="mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
- use self::generic as arch;
-
-
-diff --git a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
-index da9d9d5bfdc0..3d47471f0ef0 100644
 --- src/llvm-project/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
 +++ src/llvm-project/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
 @@ -16,6 +16,8 @@
@@ -77,21 +58,39 @@ index da9d9d5bfdc0..3d47471f0ef0 100644
  
  namespace llvm {
  namespace itanium_demangle {
-##
-## gcc (used by mrustc) has 16-byte uint128_t alignment, while rustc uses 8
-##
-#--- src/libsyntax/ast.rs
-#+++ src/libsyntax/ast.rs
-#@@ -986,2 +986,2 @@
-#-#[cfg(target_arch = "x86_64")]
-#-static_assert_size!(Expr, 96);
-#+//#[cfg(target_arch = "x86_64")]
-#+//static_assert_size!(Expr, 96);
-#--- src/librustc/ty/sty.rs
-#+++ src/librustc/ty/sty.rs
-#@@ -2258,2 +2258,2 @@
-#-#[cfg(target_arch = "x86_64")]
-#-static_assert_size!(Const<'_>, 40);
-#+//#[cfg(target_arch = "x86_64")]
-#+//static_assert_size!(Const<'_>, 40);
 
+# Disable most architecture intrinsics
+--- src/stdarch/crates/std_detect/src/detect/mod.rs
++++ src/stdarch/crates/std_detect/src/detect/mod.rs
+@@ -72,6 +72,9 @@ cfg_if! {
+         // this run-time detection logic is never called.
+         #[path = "os/other.rs"]
+         mod os;
++    } else if #[cfg(rust_compiler="mrustc")] {
++        #[path = "os/other.rs"]
++        mod os;
+     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+         // On x86/x86_64 no OS specific functionality is required.
+         #[path = "os/x86.rs"]
+
+--- vendor/ppv-lite86/src/lib.rs
++++ vendor/ppv-lite86/src/lib.rs
+@@ -9,14 +9,14 @@ mod soft;
+ mod types;
+ pub use self::types::*;
+ 
+-#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
++#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler="mrustc")))]
+ pub mod x86_64;
+-#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
++#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler="mrustc")))]
+ use self::x86_64 as arch;
+ 
+-#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
++#[cfg(any(miri, rust_compiler="mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
+ pub mod generic;
+-#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
++#[cfg(any(miri, rust_compiler="mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
+ use self::generic as arch;
+ 
+ pub use self::arch::{vec128_storage, vec256_storage, vec512_storage};

--- a/rustc-1.54.0-src.patch
+++ b/rustc-1.54.0-src.patch
@@ -28,51 +28,111 @@
  rustc_data_structures::static_assert_size!(ForeignItemKind, 72);
  
  impl From<ForeignItemKind> for ItemKind {
+
 --- compiler/rustc_hir/src/hir.rs
 +++ compiler/rustc_hir/src/hir.rs
-@@ -3050,3 +3050,3 @@
+@@ -3048,7 +3048,7 @@ impl<'hir> Node<'hir> {
+ }
+ 
  // Some nodes are used a lot. Make sure they don't unintentionally get bigger.
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 +#[cfg(all(not(rust_compiler="mrustc"),target_arch = "x86_64", target_pointer_width = "64"))]
  mod size_asserts {
+     rustc_data_structures::static_assert_size!(super::Block<'static>, 48);
+     rustc_data_structures::static_assert_size!(super::Expr<'static>, 64);
+
 --- compiler/rustc_middle/src/mir/interpret/error.rs
 +++ compiler/rustc_middle/src/mir/interpret/error.rs
-@@ -452,2 +452,2 @@
+@@ -449,7 +449,7 @@ impl dyn MachineStopType {
+     }
+ }
+ 
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 +#[cfg(all(not(rust_compiler="mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
  static_assert_size!(InterpError<'_>, 64);
+ 
+ pub enum InterpError<'tcx> {
+
 --- compiler/rustc_middle/src/mir/mod.rs
 +++ compiler/rustc_middle/src/mir/mod.rs
-@@ -2203,2 +2203,2 @@
+@@ -2200,7 +2200,7 @@ pub enum AggregateKind<'tcx> {
+     Generator(DefId, SubstsRef<'tcx>, hir::Movability),
+ }
+ 
 -#[cfg(target_arch = "x86_64")]
 +#[cfg(all(not(rust_compiler="mrustc"), target_arch = "x86_64"))]
  static_assert_size!(AggregateKind<'_>, 48);
+ 
+ #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, TyEncodable, TyDecodable, Hash, HashStable)]
+
 --- compiler/rustc_middle/src/thir.rs
 +++ compiler/rustc_middle/src/thir.rs
-@@ -147,2 +147,2 @@
+@@ -144,7 +144,7 @@ pub enum StmtKind<'tcx> {
+ }
+ 
+ // `Expr` is used a lot. Make sure it doesn't unintentionally get bigger.
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 +#[cfg(all(not(rust_compiler="mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
  rustc_data_structures::static_assert_size!(Expr<'_>, 144);
---- compiler/rustc_mir/src/interpret/place.rs
-+++ compiler/rustc_mir/src/interpret/place.rs
-@@ -91,2 +91,2 @@
--#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-+#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
- rustc_data_structures::static_assert_size!(Place, 64);
-@@ -100,2 +100,2 @@
--#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-+#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
- rustc_data_structures::static_assert_size!(PlaceTy<'_>, 80);
+ 
+ /// The Thir trait implementor lowers their expressions (`&'tcx H::Expr`)
+
 --- compiler/rustc_mir/src/interpret/operand.rs
 +++ compiler/rustc_mir/src/interpret/operand.rs
-@@ -35,2 +35,2 @@
+@@ -32,7 +32,7 @@ pub enum Immediate<Tag = ()> {
+     ScalarPair(ScalarMaybeUninit<Tag>, ScalarMaybeUninit<Tag>),
+ }
+ 
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 +#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
  rustc_data_structures::static_assert_size!(Immediate, 56);
-@@ -90,2 +90,2 @@
+ 
+ impl<Tag> From<ScalarMaybeUninit<Tag>> for Immediate<Tag> {
+@@ -87,7 +87,7 @@ pub struct ImmTy<'tcx, Tag = ()> {
+     pub layout: TyAndLayout<'tcx>,
+ }
+ 
 -#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 +#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
  rustc_data_structures::static_assert_size!(ImmTy<'_>, 72);
+ 
+ impl<Tag: Copy> std::fmt::Display for ImmTy<'tcx, Tag> {
+
+--- compiler/rustc_mir/src/interpret/place.rs
++++ compiler/rustc_mir/src/interpret/place.rs
+@@ -88,7 +88,7 @@ pub enum Place<Tag = ()> {
+     Local { frame: usize, local: mir::Local },
+ }
+ 
+-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
++#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
+ rustc_data_structures::static_assert_size!(Place, 64);
+ 
+ #[derive(Copy, Clone, Debug)]
+@@ -97,7 +97,7 @@ pub struct PlaceTy<'tcx, Tag = ()> {
+     pub layout: TyAndLayout<'tcx>,
+ }
+ 
+-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
++#[cfg(all(not(rust_compiler = "mrustc"), target_arch = "x86_64", target_pointer_width = "64"))]
+ rustc_data_structures::static_assert_size!(PlaceTy<'_>, 80);
+ 
+ impl<'tcx, Tag> std::ops::Deref for PlaceTy<'tcx, Tag> {
+
+#
+# Disable std_detect's detection logic (use the same logic as miri)
+#
+--- library/stdarch/crates/std_detect/src/detect/mod.rs
++++ library/stdarch/crates/std_detect/src/detect/mod.rs
+@@ -86,7 +86,7 @@ mod bit;
+ mod cache;
+ 
+ cfg_if! {
+-    if #[cfg(miri)] {
++    if #[cfg(any(miri, rust_compiler = "mrustc"))] {
+         // When running under miri all target-features that are not enabled at
+         // compile-time are reported as disabled at run-time.
+         //
 
 #
 # Disable crc32fast's use of stdarch
@@ -88,39 +148,9 @@
      ))] {
 
 #
-# Disable std_detect's detection logic (use the same logic as miri)
-#
---- library/stdarch/crates/std_detect/src/detect/mod.rs
-+++ library/stdarch/crates/std_detect/src/detect/mod.rs
-@@ -88,2 +88,2 @@
- cfg_if! {
--    if #[cfg(miri)] {
-+    if #[cfg(any(miri, rust_compiler = "mrustc"))] {
-
-# PPV-Lite also needs to know that we're pretending to be miri
---- vendor/ppv-lite86/src/lib.rs
-+++ vendor/ppv-lite86/src/lib.rs
-@@ -12,9 +12,9 @@
--#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
-+#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler = "mrustc")))]
- pub mod x86_64;
--#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
-+#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler = "mrustc")))]
- use self::x86_64 as arch;
- 
--#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
-+#[cfg(any(miri, rust_compiler = "mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
- pub mod generic;
--#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
-+#[cfg(any(miri, rust_compiler = "mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
- use self::generic as arch;
-
-#
 # Backport which is required to support arm64 on macOS 12
 # See: https://github.com/alexcrichton/curl-rust/commit/0aea09c428b9bc2bcf46da0fc33959fe3f03c74a
 #
-diff --git vendor/curl/src/lib.rs vendor/curl/src/lib.rs
-index 9f2e50ea9b..50eaba742b 100644
 --- vendor/curl/src/lib.rs
 +++ vendor/curl/src/lib.rs
 @@ -82,6 +82,9 @@ pub mod easy;
@@ -249,3 +279,26 @@ index 9f2e50ea9b..50eaba742b 100644
 +        assert!(INITIALIZED.load(std::sync::atomic::Ordering::SeqCst));
 +    }
 +}
+
+# PPV-Lite also needs to know that we're pretending to be miri
+--- vendor/ppv-lite86/src/lib.rs
++++ vendor/ppv-lite86/src/lib.rs
+@@ -9,14 +9,14 @@ mod soft;
+ mod types;
+ pub use self::types::*;
+ 
+-#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
++#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler = "mrustc")))]
+ pub mod x86_64;
+-#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri)))]
++#[cfg(all(feature = "simd", target_arch = "x86_64", not(miri), not(rust_compiler = "mrustc")))]
+ use self::x86_64 as arch;
+ 
+-#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
++#[cfg(any(miri, rust_compiler = "mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
+ pub mod generic;
+-#[cfg(any(miri, not(all(feature = "simd", any(target_arch = "x86_64")))))]
++#[cfg(any(miri, rust_compiler = "mrustc", not(all(feature = "simd", any(target_arch = "x86_64")))))]
+ use self::generic as arch;
+ 
+ pub use self::arch::{vec128_storage, vec256_storage, vec512_storage};


### PR DESCRIPTION
This should fix #298. `1.39.0` seems to work fine as-is, so left it for now.

An alternative would be to update the docs to instruct macOS users to avoid "Apple patch" i.e:
```bash
# patch --version 
patch 2.0-12u11-Apple
```
and instead install and use something like GNU patch. i.e `brew install gpatch`.
Happy to do that in this PR if you'd prefer.