### PR TITLE
doc: add `pkg-config` to build deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Dependencies
 - `libz-dev` (used to reduce size of bytecode files, linux only - windows uses vcpkg to download it)
 - `curl` (for downloading the rust source, linux only)
 - `cmake` (at least 3.4.3, required for building llvm in rustc)
+- `pkg-config` (required for find crate build deps, i.e libssl)
 - `python3` (required for building llvm in rustc)
 
 Linux GNU and macOS


### PR DESCRIPTION
This is required to find crate deps, i.e libssl. i.e:
```bash
make -C run_rustc
...
thread 'main' panicked at "

Could not find directory of OpenSSL installation, and this "-sys" crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

Make sure you also have the development packages of openssl installed.
For example, "libssl-dev" on Ubuntu or `openssl-devel` on Fedora.

If you are in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

    $HOST = x86_64-linux-gnu
    $TARGET = x86_64-linux-gnu
    openssl-sys = 0.9.35

", rustc-1.29.0-src/src/vendor/openssl-sys/build/main.rs:265:21
Process was terminated with signal 6
FAILING COMMAND:  /mrustc/output/cargo-build/build_openssl-sys-0_9_35_run
Calling /mrustc/output/cargo-build/build_openssl-sys-0_9_35_run failed (see /mrustc/output/cargo-build/build_openssl-sys-0_9_35.txt_failed.txt for stdout)

# cat /mrustc/output/cargo-build/build_openssl-sys-0_9_35.txt_failed.txt
cargo:rerun-if-env-changed=X86_64_LINUX_GNU_OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=X86_64_LINUX_GNU_OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=X86_64_LINUX_GNU_OPENSSL_DIR
cargo:rerun-if-env-changed=OPENSSL_DIR
run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"
```

Where the issue is ultimately failing to run `pkg-config`.