### PR TITLE
1.54.0: patch LLVM for GCC 13.2.1

### DIFF
--- a/rustc-1.54.0-src.patch
+++ b/rustc-1.54.0-src.patch
@@ -302,3 +302,14 @@
  use self::generic as arch;
  
  pub use self::arch::{vec128_storage, vec256_storage, vec512_storage};
+
+--- src/llvm-project/llvm/include/llvm/Support/Signals.h
++++ src/llvm-project/llvm/include/llvm/Support/Signals.h
+@@ -14,6 +14,7 @@
+ #ifndef LLVM_SUPPORT_SIGNALS_H
+ #define LLVM_SUPPORT_SIGNALS_H
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace llvm {


### PR DESCRIPTION
Compiling on aarch64 (using `./build-1.54.0.sh`), with GCC 13.2.1, I currently see the following failure:
```bash
In file included from /root/mrustc/rustc-1.54.0-src/src/llvm-project/llvm/lib/Support/Signals.cpp:14:
/root/mrustc/rustc-1.54.0-src/src/llvm-project/llvm/include/llvm/Support/Signals.h:119:8: error: variable or field ‘CleanupOnSignal’ declared void
  119 |   void CleanupOnSignal(uintptr_t Context);
      |        ^~~~~~~~~~~~~~~
/root/mrustc/rustc-1.54.0-src/src/llvm-project/llvm/include/llvm/Support/Signals.h:119:24: error: ‘uintptr_t’ was not declared in this scope
  119 |   void CleanupOnSignal(uintptr_t Context);
      |                        ^~~~~~~~~
/root/mrustc/rustc-1.54.0-src/src/llvm-project/llvm/include/llvm/Support/Signals.h:18:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   17 | #include <string>
  +++ |+#include <cstdint>
   18 |
In file included from /root/mrustc/rustc-1.54.0-src/src/llvm-project/llvm/lib/Support/Signals.cpp:225:
/root/mrustc/rustc-1.54.0-src/src/llvm-project/llvm/lib/Support/Unix/Signals.inc:348:44: error: ‘void llvm::sys::CleanupOnSignal(uintptr_t)’ should have been declared inside ‘llvm::sys’
  348 | void sys::CleanupOnSignal(uintptr_t Context) {
      |                                            ^
make[3]: *** [lib/Support/CMakeFiles/LLVMSupport.dir/build.make:1882: lib/Support/CMakeFiles/LLVMSupport.dir/Signals.cpp.o] Error 1
```