### PR TITLE
Debug - Declare operator<< before its use.

### DIFF
--- a/tools/common/debug.h
+++ b/tools/common/debug.h
@@ -30,6 +30,9 @@ extern void Debug_Print(dbg_cb_t cb);
 #endif
 #define TODO(fmt)   do { ::std::cerr << "TODO: " << fmt << ::std::endl; abort(); } while(0)
 
+template<typename T>
+::std::ostream& operator<<(::std::ostream& os, const ::std::vector<T>& v);
+
 namespace {
     static inline void format_to_stream(::std::ostream& os) {
     }


### PR DESCRIPTION
format_to_stream uses operator<< on vectors but it is defined earlier.

Fixes: https://github.com/thepowersgang/mrustc/issues/336