### PR TITLE
Generate reproducible output tarballs and report if they are identical

### DIFF
--- a/TestRustcBootstrap.sh
+++ b/TestRustcBootstrap.sh
@@ -69,8 +69,12 @@ rm -rf ${WORKDIR}build/rustc-${RUSTC_VERSION_NEXT}-src/build
 cleanup_mrustc
 trap - EXIT
 rm -rf ${WORKDIR}mrustc-output
-cp -r ${WORKDIR}mrustc/rustc-${RUSTC_VERSION_NEXT}-src/build/${RUSTC_TARGET}/stage2 ${WORKDIR}mrustc-output
-tar -czf ${WORKDIR}mrustc.tar.gz -C ${WORKDIR} mrustc-output
+rm -rf ${WORKDIR}output
+cp -r ${WORKDIR}mrustc/rustc-${RUSTC_VERSION_NEXT}-src/build/${RUSTC_TARGET}/stage3 ${WORKDIR}output
+cp ${WORKDIR}mrustc/rustc-${RUSTC_VERSION_NEXT}-src/build/${RUSTC_TARGET}/stage3-tools-bin/* ${WORKDIR}output/bin/
+rm -rf ${WORKDIR}output/lib/rustlib/src ${WORKDIR}output/lib/rustlib/rustc-src
+tar --mtime="@0" --sort=name -czf ${WORKDIR}mrustc.tar.gz -C ${WORKDIR} output
+mv ${WORKDIR}output ${WORKDIR}mrustc-output
 
 #
 # Build rustc by downloading the previous version of rustc (and its matching cargo)
@@ -92,5 +96,14 @@ echo "--- Running x.py, see ${WORKDIR}official.log for progress"
 (cd ${WORKDIR}build/rustc-${RUSTC_VERSION_NEXT}-src/ && ./x.py build --stage 3) > ${WORKDIR}official.log 2>&1
 (cd ${WORKDIR} && mv build official)
 rm -rf ${WORKDIR}official-output
-cp -r ${WORKDIR}official/rustc-${RUSTC_VERSION_NEXT}-src/build/${RUSTC_TARGET}/stage2 ${WORKDIR}official-output
-tar -czf ${WORKDIR}official.tar.gz -C ${WORKDIR} official-output
+rm -rf ${WORKDIR}output
+cp -r ${WORKDIR}official/rustc-${RUSTC_VERSION_NEXT}-src/build/${RUSTC_TARGET}/stage3 ${WORKDIR}output
+cp ${WORKDIR}official/rustc-${RUSTC_VERSION_NEXT}-src/build/${RUSTC_TARGET}/stage3-tools-bin/* ${WORKDIR}output/bin/
+rm -rf ${WORKDIR}output/lib/rustlib/src ${WORKDIR}output/lib/rustlib/rustc-src
+tar --mtime="@0" --sort=name -czf ${WORKDIR}official.tar.gz -C ${WORKDIR} output
+mv ${WORKDIR}output ${WORKDIR}official-output
+
+#
+# Compare mrustc-built and official build artifacts
+#
+diff -qs ${WORKDIR}mrustc.tar.gz ${WORKDIR}official.tar.gz


### PR DESCRIPTION
Use stage3 instead of stage2 to create the tarballs - although they are meant to be identical with regards to binaries included in stage2, stage3 builds more, including cargo.