### PR TITLE
Fix target-name for powerpc64le.

### DIFF
--- a/tools/common/target_detect.h
+++ b/tools/common/target_detect.h
@@ -60,9 +60,9 @@
 #  endif
 # elif defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
 #  if defined(__USE_GNU)
-#   define DEFAULT_TARGET_NAME "powerpcle64-unknown-linux-gnu"
+#   define DEFAULT_TARGET_NAME "powerpc64le-unknown-linux-gnu"
 #  else
-#   define DEFAULT_TARGET_NAME "powerpcle64-unknown-linux-musl"
+#   define DEFAULT_TARGET_NAME "powerpc64le-unknown-linux-musl"
 #  endif
 # elif defined(__riscv) && __riscv_xlen == 64
 #  if defined(__USE_GNU)


### PR DESCRIPTION
* tools/common/target_detect.h: Fix typo in powerpc64le-* triplets.