### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ TAIL_COUNT ?= 10
 
 LINKFLAGS := -g
 LIBS := -lz
-CXXFLAGS := -g -Wall
+CXXFLAGS := -g -Wall -Wno-unqualified-std-cast-call
 CXXFLAGS += -std=c++14
 #CXXFLAGS += -Wextra
 CXXFLAGS += -O2

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ $(OBJDIR)%.o: src/%.cpp
 $(OBJDIR)version.o: $(OBJDIR)%.o: src/%.cpp $(filter-out $(OBJDIR)version.o,$(OBJ)) Makefile
 	@+mkdir -p $(dir $@)
 	@echo [CXX] -o $@
-	$V$(CXX) -o $@ -c $< $(CXXFLAGS) $(CPPFLAGS) -MMD -MP -MF $@.dep -D VERSION_GIT_FULLHASH=\"$(shell git show --pretty=%H -s --no-show-signature)\" -D VERSION_GIT_BRANCH="\"$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)\"" -D VERSION_GIT_SHORTHASH=\"$(shell git show -s --pretty=%h --no-show-signature)\" -D VERSION_BUILDTIME="\"$(shell date -uR)\"" -D VERSION_GIT_ISDIRTY=$(shell git diff-index --quiet HEAD; echo $$?)
+	$V$(CXX) -o $@ -c $< $(CXXFLAGS) $(CPPFLAGS) -MMD -MP -MF $@.dep -D VERSION_GIT_FULLHASH=\"$(shell git show --pretty=%H -s --no-show-signature)\" -D VERSION_GIT_BRANCH="\"$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)\"" -D VERSION_GIT_SHORTHASH=\"$(shell git show -s --pretty=%h --no-show-signature)\" -D VERSION_BUILDTIME="\"$(shell env LC_TIME=C date -u +"%a, %e %b %Y %T +0000")\"" -D VERSION_GIT_ISDIRTY=$(shell git diff-index --quiet HEAD; echo $$?)
 
 src/main.cpp: $(PCHS:%=src/%.gch)
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ TAIL_COUNT ?= 10
 
 LINKFLAGS := -g
 LIBS := -lz
-CXXFLAGS := -g -Wall -Wno-unqualified-std-cast-call
+CXXFLAGS := -g -Wall
 CXXFLAGS += -std=c++14
 #CXXFLAGS += -Wextra
 CXXFLAGS += -O2
@@ -56,6 +56,7 @@ CXXFLAGS += -Wno-pessimizing-move
 CXXFLAGS += -Wno-misleading-indentation
 #CXXFLAGS += -Wno-unused-private-field
 #CXXFLAGS += -Wno-unknown-warning-option
+#CXXFLAGS += -Wno-unqualified-std-cast-call
 
 CXXFLAGS += -Werror=return-type
 CXXFLAGS += -Werror=switch

--- a/TestRustcBootstrap.sh
+++ b/TestRustcBootstrap.sh
@@ -46,7 +46,7 @@ rm -rf ${WORKDIR}build
 #
 echo "=== Building rustc bootstrap mrustc stage0"
 mkdir -p ${WORKDIR}mrustc/
-tar -xf rustc-${RUSTC_VERSION_NEXT}-src.tar.gz -C ${WORKDIR}mrustc/
+tar -xzf rustc-${RUSTC_VERSION_NEXT}-src.tar.gz -C ${WORKDIR}mrustc/
 cat - > ${WORKDIR}mrustc/rustc-${RUSTC_VERSION_NEXT}-src/config.toml <<EOF
 [build]
 cargo = "${PREFIX}bin/cargo"
@@ -81,7 +81,7 @@ mv ${WORKDIR}output ${WORKDIR}mrustc-output
 #
 echo "=== Building rustc bootstrap downloaded stage0"
 mkdir -p ${WORKDIR}official/
-tar -xf rustc-${RUSTC_VERSION_NEXT}-src.tar.gz -C ${WORKDIR}official/
+tar -xzf rustc-${RUSTC_VERSION_NEXT}-src.tar.gz -C ${WORKDIR}official/
 cat - > ${WORKDIR}official/rustc-${RUSTC_VERSION_NEXT}-src/config.toml <<EOF
 [build]
 full-bootstrap = true

--- a/minicargo.mk
+++ b/minicargo.mk
@@ -210,7 +210,7 @@ $(RUSTC_SRC_TARBALL):
 	@rm -f $@
 	@curl -sS https://static.rust-lang.org/dist/$@ -o $@
 rustc-$(RUSTC_VERSION)-src/extracted: $(RUSTC_SRC_TARBALL)
-	tar -xf $(RUSTC_SRC_TARBALL)
+	tar -xzf $(RUSTC_SRC_TARBALL)
 	touch $@
 $(RUSTC_SRC_DL): rustc-$(RUSTC_VERSION)-src/extracted rustc-$(RUSTC_VERSION)-src.patch
 	cd $(RUSTCSRC) && patch -p0 < ../rustc-$(RUSTC_VERSION)-src.patch;

--- a/tools/minicargo/manifest.h
+++ b/tools/minicargo/manifest.h
@@ -14,6 +14,11 @@
 #include <functional>
 #include <path.h>
 
+#ifdef __OpenBSD__
+# undef major
+# undef minor
+#endif
+
 class WorkspaceManifest;
 class PackageManifest;
 class Repository;

--- a/tools/minicargo/manifest.h
+++ b/tools/minicargo/manifest.h
@@ -15,6 +15,8 @@
 #include <path.h>
 
 #ifdef __OpenBSD__
+// major() and minor() are defined as macros in <sys/types.h> on OpenBSD
+// see: https://man.openbsd.org/major.3
 # undef major
 # undef minor
 #endif


### PR DESCRIPTION
I was able to build and use mrustc on *OpenBSD*, but with a few changes.
To be able to use mrustc, I had to set `CC=egcc` (gcc-11.2.0),
because `compiler_builtins` would emit wrong assembly for clang.

Please test my changes, so they don't affect other systems.

<details>
<summary>compiler_builtins failure with clang:</summary>

```
--- BUILDING compiler_builtins v0.1.101 (15.8% 1r,0w,15b,3c/19t)
> tools/bin/mrustc rustc-1.74.0-src/vendor/compiler_builtins/src/lib.rs -o output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib -C emit-depfile=output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.d --cfg debug_assertions -O -L output-1.74.0 --cfg feature="compiler-builtins" --cfg feature="rustc-dep-of-std" --cfg feature="core" --cfg feature="dep:core" --crate-name compiler_builtins --crate-type rlib --crate-tag 0_1_101_H10c --cfg feature="unstable" --edition 2018 --extern core=output-1.74.0/librustc_std_workspace_core-1_99_0.rlib > output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib_dbg.txt
 (15.8% 1r,0w,15b,3c/19t): compiler_builtins v0.1.101
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:14252:83: error: invalid input constraint '0' in asm
        __asm__ __volatile__("div %2;\n " : "+r" (asm_rax), "+r" (asm_rdx) : "r" (arg1), "0" (asm_rax), "1" (asm_rdx):);
                                                                                         ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:14349:84: error: invalid input constraint '0' in asm
        __asm__ __volatile__("div %2;\n " : "+r" (asm_rax), "+r" (asm_rdx) : "r" (var38), "0" (asm_rax), "1" (asm_rdx):);
                                                                                          ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:14399:83: error: invalid input constraint '0' in asm
        __asm__ __volatile__("div %2;\n " : "+r" (asm_rax), "+r" (asm_rdx) : "r" (var3), "0" (asm_rax), "1" (asm_rdx):);
                                                                                         ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:14424:83: error: invalid input constraint '0' in asm
        __asm__ __volatile__("div %2;\n " : "+r" (asm_rax), "+r" (asm_rdx) : "r" (var3), "0" (asm_rax), "1" (asm_rdx):);
                                                                                         ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:16076:89: error: invalid input constraint '0' in asm
        __asm__ __volatile__("rep movsb;\n " : "+r" (asm_rdi), "+r" (asm_rsi) : "r" (asm_ecx), "0" (asm_rdi), "1" (asm_rsi):);
                                                                                               ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:16087:89: error: invalid input constraint '0' in asm
        __asm__ __volatile__("rep movsq;\n " : "+r" (asm_rdi), "+r" (asm_rsi) : "r" (asm_rcx), "0" (asm_rdi), "1" (asm_rsi):);
                                                                                               ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:16145:73: error: invalid input constraint '0' in asm
        __asm__ __volatile__("rep stosb;\n " : "+r" (asm_rdi) : "r" (asm_ecx), "0" (asm_rdi), "r" (asm_rax):);
                                                                               ^
output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.c:16154:73: error: invalid input constraint '0' in asm
        __asm__ __volatile__("rep stosq;\n " : "+r" (asm_rdi) : "r" (asm_rcx), "0" (asm_rdi), "r" (asm_rax):);
                                                                               ^
8 errors generated.
C Compiler failed to execute - error code 256
Process exited with non-zero exit status 1
FAILING COMMAND: tools/bin/mrustc rustc-1.74.0-src/vendor/compiler_builtins/src/lib.rs -o output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib -C emit-depfile=output-1.74.0/libcompiler_builtins-0_1_101_H10c.rlib.d --cfg debug_assertions
-O -L output-1.74.0 --cfg feature="compiler-builtins" --cfg feature="rustc-dep-of-std" --cfg feature="core" --cfg feature="dep:core" --crate-name compiler_builtins --crate-type rlib --crate-tag 0_1_101_H10c --cfg feature="unstable" --edition 2018 --extern core=output-1.74.0/librustc_std_workspace_core-1_99_0.rlib
```

</details>