### PR TITLE
Allow `&data[..crate::VALUE]`

### DIFF
--- a/src/parse/expr.cpp
+++ b/src/parse/expr.cpp
@@ -840,6 +840,7 @@ bool Parse_IsTokValue(eTokenType tok_type)
     case TOK_RWORD_FALSE:
     case TOK_RWORD_SELF:
     case TOK_RWORD_SUPER:
+    case TOK_RWORD_CRATE:
     case TOK_RWORD_BOX:
     case TOK_RWORD_IN:
     case TOK_PAREN_OPEN:


### PR DESCRIPTION
This fixes one issue for #355 