### PR TITLE
RISC-V Cross-Compilation

### DIFF
--- a/src/expand/asm.cpp
+++ b/src/expand/asm.cpp
@@ -218,12 +218,21 @@ namespace {
         ERROR(sp, E0000, "Unknown register for x86/x86-64 - `" << str << "`");
     }
 
+    AsmCommon::RegisterClass get_reg_class_riscv(const Span &sp, const RcString& str)
+    {
+        if(str == "reg"    )    return AsmCommon::RegisterClass::riscv_reg;
+        if(str == "freg"   )    return AsmCommon::RegisterClass::riscv_freg;
+        ERROR(sp, E0000, "Unknown register for riscv64 - `" << str << "`");
+    }
+
     AsmCommon::RegisterClass get_reg_class(const Span& sp, const RcString& str)
     {
         if(Target_GetCurSpec().m_arch.m_name == "x86_64")
             return get_reg_class_x8664(sp, str);
         if(Target_GetCurSpec().m_arch.m_name == "x86")
             return get_reg_class_x8664(sp, str);
+        if (Target_GetCurSpec().m_arch.m_name == "riscv64")
+            return get_reg_class_riscv(sp, str);
         ERROR(sp, E0000, "Unknown architecture for asm!");
     }
 }

--- a/src/hir/asm.hpp
+++ b/src/hir/asm.hpp
@@ -54,8 +54,8 @@ namespace AsmCommon {
         //nvptx_reg32,
         //nvptx_reg64,
         
-        //riscv_reg,
-        //riscv_freg,
+        riscv_reg,
+        riscv_freg,
         
         //hexagon_reg,
         
@@ -106,6 +106,8 @@ namespace AsmCommon {
         case RegisterClass::x86_ymm:    return "ymm_reg";
         case RegisterClass::x86_zmm:    return "zmm_reg";
         case RegisterClass::x86_kreg:   return "kreg";
+        case RegisterClass::riscv_reg:  return "reg";
+        case RegisterClass::riscv_freg: return "freg";
         }
         throw "";
     }

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -5441,6 +5441,7 @@ namespace {
                         // https://gcc.gnu.org/onlinedocs/gcc/Machine-Constraints.html
                         switch(c)
                         {
+                        // x86
                         case AsmCommon::RegisterClass::x86_reg: m_of << "r";   break;
                         case AsmCommon::RegisterClass::x86_reg_abcd: m_of << "Q";   break;
                         case AsmCommon::RegisterClass::x86_reg_byte: m_of << "q";   break;
@@ -5448,6 +5449,9 @@ namespace {
                         case AsmCommon::RegisterClass::x86_ymm: m_of << "x";   break;
                         case AsmCommon::RegisterClass::x86_zmm: m_of << "v";   break;
                         case AsmCommon::RegisterClass::x86_kreg: m_of << "Yk"; break;
+                        // riscv
+                        case AsmCommon::RegisterClass::riscv_reg: m_of << "r"; break;
+                        case AsmCommon::RegisterClass::riscv_freg: m_of << "f"; break;
                         }
                     TU_ARMA(Explicit, name) {
                         m_of << "r";
@@ -5478,6 +5482,7 @@ namespace {
                         TU_ARMA(Class, c)
                             switch(c)
                             {
+                            // x86
                             case AsmCommon::RegisterClass::x86_reg: m_of << "r";   break;
                             case AsmCommon::RegisterClass::x86_reg_abcd: m_of << "Q";   break;
                             case AsmCommon::RegisterClass::x86_reg_byte: m_of << "q";   break;
@@ -5485,6 +5490,9 @@ namespace {
                             case AsmCommon::RegisterClass::x86_ymm: m_of << "x";   break;
                             case AsmCommon::RegisterClass::x86_zmm: m_of << "v";   break;
                             case AsmCommon::RegisterClass::x86_kreg: m_of << "Yk"; break;
+                            // riscv
+                            case AsmCommon::RegisterClass::riscv_reg: m_of << "r"; break;
+                            case AsmCommon::RegisterClass::riscv_freg: m_of << "f"; break;
                             }
                         TU_ARMA(Explicit, name) {
                             auto it = ::std::find(outputs.begin(), outputs.end(), &r);

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -497,6 +497,13 @@ namespace
                 ARCH_RISCV64
                 };
         }
+        else if(target_name == "riscv64-unknown-linux-musl")
+        {
+            return TargetSpec {
+                "unix", "linux", "musl", {CodegenMode::Gnu11, false, "riscv64-unknown-linux-musl", BACKEND_C_OPTS_GNU},
+                ARCH_RISCV64
+                };
+        }
         else if(target_name == "i586-pc-windows-gnu")
         {
             return TargetSpec {

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -155,6 +155,22 @@ namespace
                         {
                             rv.m_arch = ARCH_M68K;
                         }
+                        else if( key_val.value.as_string() == ARCH_POWERPC32.m_name )
+                        {
+                            rv.m_arch = ARCH_POWERPC32;
+                        }
+                        else if( key_val.value.as_string() == ARCH_POWERPC64.m_name )
+                        {
+                            rv.m_arch = ARCH_POWERPC64;
+                        }
+                        else if( key_val.value.as_string() == ARCH_POWERPC64LE.m_name )
+                        {
+                            rv.m_arch = ARCH_POWERPC64LE;
+                        }
+                        else if( key_val.value.as_string() == ARCH_RISCV64.m_name )
+                        {
+                            rv.m_arch = ARCH_RISCV64;
+                        }
                         else
                         {
                             // Error.

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -902,7 +902,7 @@ RunnableJob Job_BuildTarget::start()
         }
         else {
             args.push_back("--target"); args.push_back(parent.m_opts.target_name);
-            args.push_back("-C"); args.push_back(format("emit-build-command=",outfile,".sh"));
+            //args.push_back("-C"); args.push_back(format("emit-build-command=",outfile,".sh"));
         }
     }
 


### PR DESCRIPTION
With these changes, I can build mrustc for x86_64-unknown-openbsd and generate binaries for riscv64-unknown-linux-musl.
I have an accompanying C cross-compiler for the target.
I'm also planning on making ARM work.