### PR TITLE
refactor: add missing std lib includes

### DIFF
--- a/src/ast/path.hpp
+++ b/src/ast/path.hpp
@@ -9,6 +9,7 @@
 #define AST_PATH_HPP_INCLUDED
 
 #include "../common.hpp"
+#include <cstdint>
 #include <string>
 #include <stdexcept>
 #include <vector>

--- a/src/ast/types.hpp
+++ b/src/ast/types.hpp
@@ -8,6 +8,7 @@
 #ifndef TYPES_HPP_INCLUDED
 #define TYPES_HPP_INCLUDED
 
+#include <cstdint>
 #include <memory>
 
 #include "../common.hpp"

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -5,6 +5,7 @@
  * debug.cpp
  * - Debug printing (with indenting)
  */
+#include <cstdint>
 #include <debug_inner.hpp>
 #include <debug.hpp>
 #include <set>

--- a/src/hir/generic_ref.hpp
+++ b/src/hir/generic_ref.hpp
@@ -6,6 +6,7 @@
  * - Reference to a generic
  */
 #pragma once
+#include <cstdint>
 #include <rc_string.hpp>
 
 /// Binding index for a Generic that indicates "Self"

--- a/src/hir/type_ref.hpp
+++ b/src/hir/type_ref.hpp
@@ -7,6 +7,7 @@
 */
 #pragma once
 
+#include <cstdint>
 #include <rc_string.hpp>
 #include <span.hpp>
 

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <cassert>
 
+#include <cstdint>
 #include <unordered_map>
 #include <algorithm>    // sort/find_if
 


### PR DESCRIPTION
This fixes compile issues when using GCC 15 (gcc (GCC) 15.0.1 20250329 (Red Hat 15.0.1-0)):
```bash
[CXX] -o .obj/debug.o
src/debug.cpp: In function ‘std::ostream& operator<<(std::ostream&, const FmtEscaped&)’:
src/debug.cpp:163:13: error: ‘uint8_t’ was not declared in this scope
  163 |             uint8_t v = *s;
```

See porting to GCC 15 (https://gcc.gnu.org/gcc-15/porting_to.html):

> In particular, the following headers are used less widely within
> libstdc++ and may need to be included explicitly when compiling with GCC 15:
> <stdint.h> (for int8_t, int32_t etc.) and <cstdint> (for std::int8_t, std::int32_t etc.)