### PR TITLE
fix: link against Security framework on macOS

### DIFF
--- a/script-overrides/stable-1.54.0-macos/build_std.txt
+++ b/script-overrides/stable-1.54.0-macos/build_std.txt
@@ -1,2 +1,3 @@
 cargo:rustc-cfg=backtrace_in_libstd
 cargo:rustc-env=STD_ENV_ARCH=x86_64
+cargo:rustc-link-lib=framework=Security


### PR DESCRIPTION
Without this change running `./build-1.54.0.sh` resulted in the following error:

```
--- BUILDING cargo v0.55.0 [bin cargo] (99.4% 1r,0w,0b,171c/172t)
> /private/var/folders/ny/24b_8d310kb6_z930jng0hhw0000gn/T/tmp.xDq9hgAsn0/mrustc/bin/mrustc /private/var/folders/ny/24b_8d310kb6_z930jng0hhw0000gn/T/tmp.xDq9hgAsn0/mrustc/rustc-1.54.0-src/src/tools/cargo/src/bin/cargo/main.rs -o output-1.54.0/cargo-build/cargo -C emit-depfile=output-1.54.0/cargo-build/cargo.d --cfg debug_assertions -O -L output-1.54.0 -L output-1.54.0/cargo-build --cfg feature="vendored-openssl" --cfg feature="openssl" --cfg feature="dep:openssl" --crate-name cargo --crate-type bin --crate-tag 0_55_0_H100000800000000 --extern cargo=output-1.54.0/cargo-build/libcargo-0_55_0_H100000800000000.rlib --edition 2018 --extern atty=output-1.54.0/cargo-build/libatty-0_2_14.rlib --extern bytesize=output-1.54.0/cargo-build/libbytesize-1_0_1.rlib --extern cargo_platform=output-1.54.0/cargo-build/libcargo_platform-0_1_1.rlib --extern cargo_util=output-1.54.0/cargo-build/libcargo_util-0_1_0.rlib --extern crates_io=output-1.54.0/cargo-build/libcrates_io-0_33_0.rlib --extern crossbeam_utils=output-1.54.0/cargo-build/libcrossbeam_utils-0_8_5_H2a.rlib --extern curl=output-1.54.0/cargo-build/libcurl-0_4_36_H430a.rlib --extern curl_sys=output-1.54.0/cargo-build/libcurl_sys-0_4_42_H894.rlib --extern env_logger=output-1.54.0/cargo-build/libenv_logger-0_8_3_H1b.rlib --extern anyhow=output-1.54.0/cargo-build/libanyhow-1_0_40_H8.rlib --extern filetime=output-1.54.0/cargo-build/libfiletime-0_2_14.rlib --extern flate2=output-1.54.0/cargo-build/libflate2-1_0_20_H20081.rlib --extern git2=output-1.54.0/cargo-build/libgit2-0_13_17_H36a.rlib --extern git2_curl=output-1.54.0/cargo-build/libgit2_curl-0_14_1.rlib --extern glob=output-1.54.0/cargo-build/libglob-0_3_0.rlib --extern hex=output-1.54.0/cargo-build/libhex-0_4_2_H40.rlib --extern home=output-1.54.0/cargo-build/libhome-0_5_3.rlib --extern humantime=output-1.54.0/cargo-build/libhumantime-2_0_1.rlib --extern ignore=output-1.54.0/cargo-build/libignore-0_4_17.rlib --extern lazy_static=output-1.54.0/cargo-build/liblazy_static-1_4_0.rlib --extern jobserver=output-1.54.0/cargo-build/libjobserver-0_1_22.rlib --extern lazycell=output-1.54.0/cargo-build/liblazycell-1_3_0.rlib --extern libc=output-1.54.0/cargo-build/liblibc-0_2_95_H21.rlib --extern log=output-1.54.0/cargo-build/liblog-0_4_14_H80000.rlib --extern libgit2_sys=output-1.54.0/cargo-build/liblibgit2_sys-0_12_18_H1aa.rlib --extern memchr=output-1.54.0/cargo-build/libmemchr-2_4_0_Hc.rlib --extern num_cpus=output-1.54.0/cargo-build/libnum_cpus-1_13_0.rlib --extern opener=output-1.54.0/cargo-build/libopener-0_4_1.rlib --extern percent_encoding=output-1.54.0/cargo-build/libpercent_encoding-2_1_0.rlib --extern rustfix=output-1.54.0/cargo-build/librustfix-0_5_1.rlib --extern semver=output-1.54.0/cargo-build/libsemver-1_0_3_H3.rlib --extern serde=output-1.54.0/cargo-build/libserde-1_0_126_H1a.rlib --extern serde_ignored=output-1.54.0/cargo-build/libserde_ignored-0_1_2.rlib --extern serde_json=output-1.54.0/cargo-build/libserde_json-1_0_64_H14480.rlib --extern shell_escape=output-1.54.0/cargo-build/libshell_escape-0_1_5.rlib --extern strip_ansi_escapes=output-1.54.0/cargo-build/libstrip_ansi_escapes-0_1_0.rlib --extern tar=output-1.54.0/cargo-build/libtar-0_4_35.rlib --extern tempfile=output-1.54.0/cargo-build/libtempfile-3_2_0.rlib --extern termcolor=output-1.54.0/cargo-build/libtermcolor-1_1_2.rlib --extern toml=output-1.54.0/cargo-build/libtoml-0_5_7.rlib --extern unicode_xid=output-1.54.0/cargo-build/libunicode_xid-0_2_2.rlib --extern url=output-1.54.0/cargo-build/liburl-2_2_2_H20.rlib --extern walkdir=output-1.54.0/cargo-build/libwalkdir-2_3_2.rlib --extern clap=output-1.54.0/cargo-build/libclap-2_33_3_H43013.rlib --extern unicode_width=output-1.54.0/cargo-build/libunicode_width-0_1_8.rlib --extern openssl=output-1.54.0/cargo-build/libopenssl-0_10_33_H1004.rlib --extern im_rc=output-1.54.0/cargo-build/libim_rc-15_0_0.rlib --extern itertools=output-1.54.0/cargo-build/libitertools-0_10_0_Hc0.rlib --extern rustc_workspace_hack=output-1.54.0/cargo-build/librustc_workspace_hack-1_0_0.rlib --extern rand=output-1.54.0/cargo-build/librand-0_8_3_H3070d.rlib --extern regex=output-1.54.0/cargo-build/libregex-1_4_3_H3ff9f5.rlib > output-1.54.0/cargo-build/cargo_dbg.txt
 (99.4% 1r,0w,0b,171c/172t): cargo v0.55.0 [bin cargo]
<null> warn:0:Multiple panic_runtime crates loaded - panic_abort-0_0_0 and panic_unwind-0_0_0
ld: warning: ignoring duplicate libraries: '-lSystem', '-liconv'
Undefined symbols for architecture arm64:
  "_SSLClose", referenced from:
      _stransport_close in libgit2.a[139](stransport.c.o)
  "_SSLCopyPeerTrust", referenced from:
      _stransport_connect in libgit2.a[139](stransport.c.o)
      _stransport_certificate in libgit2.a[139](stransport.c.o)
  "_SSLCreateContext", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLHandshake", referenced from:
      _stransport_connect in libgit2.a[139](stransport.c.o)
  "_SSLRead", referenced from:
      _stransport_read in libgit2.a[139](stransport.c.o)
  "_SSLSetConnection", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLSetIOFuncs", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLSetPeerDomainName", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLSetProtocolVersionMax", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLSetProtocolVersionMin", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLSetSessionOption", referenced from:
      _stransport_wrap in libgit2.a[139](stransport.c.o)
  "_SSLWrite", referenced from:
      _stransport_write in libgit2.a[139](stransport.c.o)
  "_SecCertificateCopyData", referenced from:
      _stransport_certificate in libgit2.a[139](stransport.c.o)
  "_SecCopyErrorMessageString", referenced from:
      _stransport_error in libgit2.a[139](stransport.c.o)
  "_SecTrustEvaluate", referenced from:
      _stransport_connect in libgit2.a[139](stransport.c.o)
  "_SecTrustGetCertificateAtIndex", referenced from:
      _stransport_certificate in libgit2.a[139](stransport.c.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
C Compiler failed to execute - error code 256
Process exited with non-zero exit status 1
FAILING COMMAND: /private/var/folders/ny/24b_8d310kb6_z930jng0hhw0000gn/T/tmp.xDq9hgAsn0/mrustc/bin/mrustc /private/var/folders/ny/24b_8d310kb6_z930jng0hhw0000gn/T/tmp.xDq9hgAsn0/mrustc/rustc-1.54.0-src/src/tools/cargo/src/bin/cargo/main.rs -o output-1.54.0/cargo-build/cargo -C emit-depfile=output-1.54.0/cargo-build/cargo.d --cfg debug_assertions -O -L output-1.54.0 -L output-1.54.0/cargo-build --cfg feature="vendored-openssl" --cfg feature="openssl" --cfg feature="dep:openssl" --crate-name cargo --crate-type bin --crate-tag 0_55_0_H100000800000000 --extern cargo=output-1.54.0/cargo-build/libcargo-0_55_0_H100000800000000.rlib --edition 2018 --extern atty=output-1.54.0/cargo-build/libatty-0_2_14.rlib --extern bytesize=output-1.54.0/cargo-build/libbytesize-1_0_1.rlib --extern cargo_platform=output-1.54.0/cargo-build/libcargo_platform-0_1_1.rlib --extern cargo_util=output-1.54.0/cargo-build/libcargo_util-0_1_0.rlib --extern crates_io=output-1.54.0/cargo-build/libcrates_io-0_33_0.rlib --extern crossbeam_utils=output-1.54.0/cargo-build/libcrossbeam_utils-0_8_5_H2a.rlib --extern curl=output-1.54.0/cargo-build/libcurl-0_4_36_H430a.rlib --extern curl_sys=output-1.54.0/cargo-build/libcurl_sys-0_4_42_H894.rlib --extern env_logger=output-1.54.0/cargo-build/libenv_logger-0_8_3_H1b.rlib --extern anyhow=output-1.54.0/cargo-build/libanyhow-1_0_40_H8.rlib --extern filetime=output-1.54.0/cargo-build/libfiletime-0_2_14.rlib --extern flate2=output-1.54.0/cargo-build/libflate2-1_0_20_H20081.rlib --extern git2=output-1.54.0/cargo-build/libgit2-0_13_17_H36a.rlib --extern git2_curl=output-1.54.0/cargo-build/libgit2_curl-0_14_1.rlib --extern glob=output-1.54.0/cargo-build/libglob-0_3_0.rlib --extern hex=output-1.54.0/cargo-build/libhex-0_4_2_H40.rlib --extern home=output-1.54.0/cargo-build/libhome-0_5_3.rlib --extern humantime=output-1.54.0/cargo-build/libhumantime-2_0_1.rlib --extern ignore=output-1.54.0/cargo-build/libignore-0_4_17.rlib --extern lazy_static=output-1.54.0/cargo-build/liblazy_static-1_4_0.rlib --extern jobserver=output-1.54.0/cargo-build/libjobserver-0_1_22.rlib --extern lazycell=output-1.54.0/cargo-build/liblazycell-1_3_0.rlib --extern libc=output-1.54.0/cargo-build/liblibc-0_2_95_H21.rlib --extern log=output-1.54.0/cargo-build/liblog-0_4_14_H80000.rlib --extern libgit2_sys=output-1.54.0/cargo-build/liblibgit2_sys-0_12_18_H1aa.rlib --extern memchr=output-1.54.0/cargo-build/libmemchr-2_4_0_Hc.rlib --extern num_cpus=output-1.54.0/cargo-build/libnum_cpus-1_13_0.rlib --extern opener=output-1.54.0/cargo-build/libopener-0_4_1.rlib --extern percent_encoding=output-1.54.0/cargo-build/libpercent_encoding-2_1_0.rlib --extern rustfix=output-1.54.0/cargo-build/librustfix-0_5_1.rlib --extern semver=output-1.54.0/cargo-build/libsemver-1_0_3_H3.rlib --extern serde=output-1.54.0/cargo-build/libserde-1_0_126_H1a.rlib --extern serde_ignored=output-1.54.0/cargo-build/libserde_ignored-0_1_2.rlib --extern serde_json=output-1.54.0/cargo-build/libserde_json-1_0_64_H14480.rlib --extern shell_escape=output-1.54.0/cargo-build/libshell_escape-0_1_5.rlib --extern strip_ansi_escapes=output-1.54.0/cargo-build/libstrip_ansi_escapes-0_1_0.rlib --extern tar=output-1.54.0/cargo-build/libtar-0_4_35.rlib --extern tempfile=output-1.54.0/cargo-build/libtempfile-3_2_0.rlib --extern termcolor=output-1.54.0/cargo-build/libtermcolor-1_1_2.rlib --extern toml=output-1.54.0/cargo-build/libtoml-0_5_7.rlib --extern unicode_xid=output-1.54.0/cargo-build/libunicode_xid-0_2_2.rlib --extern url=output-1.54.0/cargo-build/liburl-2_2_2_H20.rlib --extern walkdir=output-1.54.0/cargo-build/libwalkdir-2_3_2.rlib --extern clap=output-1.54.0/cargo-build/libclap-2_33_3_H43013.rlib --extern unicode_width=output-1.54.0/cargo-build/libunicode_width-0_1_8.rlib --extern openssl=output-1.54.0/cargo-build/libopenssl-0_10_33_H1004.rlib --extern im_rc=output-1.54.0/cargo-build/libim_rc-15_0_0.rlib --extern itertools=output-1.54.0/cargo-build/libitertools-0_10_0_Hc0.rlib --extern rustc_workspace_hack=output-1.54.0/cargo-build/librustc_workspace_hack-1_0_0.rlib --extern rand=output-1.54.0/cargo-build/librand-0_8_3_H3070d.rlib --extern regex=output-1.54.0/cargo-build/libregex-1_4_3_H3ff9f5.rlib
Env:  OUT_DIR=/private/var/folders/ny/24b_8d310kb6_z930jng0hhw0000gn/T/tmp.xDq9hgAsn0/mrustc/output-1.54.0/cargo-build/build_cargo-0_55_0_H100000800000000 CARGO_MANIFEST_DIR=/private/var/folders/ny/24b_8d310kb6_z930jng0hhw0000gn/T/tmp.xDq9hgAsn0/mrustc/rustc-1.54.0-src/src/tools/cargo CARGO_PKG_NAME=cargo CARGO_PKG_VERSION=0.55.0 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_MINOR=55 CARGO_PKG_VERSION_PATCH=0 DEP_GIT2_ROOT=/opt/homebrew/Cellar/libgit2/1.9.0/include
 (100.0% 0r,0w,0b,172c/172t):
BUILD FAILED
make: *** [output-1.54.0/cargo] Error 1
```

With this one it builds just fine