### PR TITLE
minicargo.mk: do not build for x86 on powerpc

### DIFF
--- a/minicargo.mk
+++ b/minicargo.mk
@@ -144,6 +144,8 @@ ifeq ($(shell uname -s || echo not),Darwin)
  # running under the Rosetta execution environment.
  ifeq ($(shell /usr/bin/uname -m || echo not),arm64)
    RUSTC_TARGET ?= aarch64-apple-darwin
+ else ifeq ($(shell /usr/bin/uname -p || echo not),powerpc)
+   RUSTC_TARGET ?= powerpc-apple-darwin
  else
    RUSTC_TARGET ?= x86_64-apple-darwin
  endif


### PR DESCRIPTION
This should fix an annoying bug which was breaking build attempts mid-way. Caveat: this assumes 32-bit powerpc, since `uname` knows nothing about build_arch. This will do for now, since ppc64 on Darwin is too exotic, restricted to 10.5 on G5 cpus and arguably less tested in gcc upstream either.
If at all we get everything working for ppc, adding ppc64 won’t be a problem.