### PR TITLE
Fix rustc-1.74-bundled llvm17 headers to build on gcc15

### DIFF
--- a/rustc-1.74.0-src.patch
+++ b/rustc-1.74.0-src.patch
@@ -124,3 +124,25 @@
 +#[cfg(all(target_pointer_width = "64", not(rust_compiler = "mrustc")))]
  from_hex_array_impl! {
 
+--- src/llvm-project/llvm/include/llvm/ADT/SmallVector.h
++++ src/llvm-project/llvm/include/llvm/ADT/SmallVector.h
+@@ -21,2 +21,3 @@
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+--- src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -14,4 +14,5 @@
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+--- src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
++++ src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+@@ -16,4 +16,5 @@
+ #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ 


### PR DESCRIPTION
Build errors this patch addresses.

#### llvm/include/llvm/ADT/SmallVector.h
```
[  0%] Building CXX object lib/Support/CMakeFiles/LLVMSupport.dir/Allocator.cpp.o
In file included from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:20,
                 from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Support/Allocator.cpp:13:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:109:62: error: ‘uint64_t’ was not declared in this scope
  109 |     std::conditional_t<sizeof(T) < 4 && sizeof(void *) >= 8, uint64_t,
      |                                                              ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:29:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   28 | #include <memory>
  +++ |+#include <cstdint>
   29 | #include <new>
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:110:24: error: ‘uint32_t’ was not declared in this scope
  110 |                        uint32_t>;
      |                        ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:110:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:110:32: error: template argument 2 is invalid
  110 |                        uint32_t>;
      |                                ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:110:32: error: template argument 3 is invalid
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:114:27: error: ‘SmallVectorSizeType’ was not declared in this scope; did you mean ‘SmallVectorBase’? [-Wtemplate-body]
  114 |   alignas(SmallVectorBase<SmallVectorSizeType<T>>) char Base[sizeof(
      |                           ^~~~~~~~~~~~~~~~~~~
      |                           SmallVectorBase
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:114:47: error: template argument 1 is invalid [-Wtemplate-body]
  114 |   alignas(SmallVectorBase<SmallVectorSizeType<T>>) char Base[sizeof(
      |                                               ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:114:48: error: expected ‘)’ before ‘>’ token [-Wtemplate-body]
  114 |   alignas(SmallVectorBase<SmallVectorSizeType<T>>) char Base[sizeof(
      |          ~                                     ^~
      |                                                )
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:114:48: error: expected unqualified-id before ‘>’ token [-Wtemplate-body]
  114 |   alignas(SmallVectorBase<SmallVectorSizeType<T>>) char Base[sizeof(
      |                                                ^~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:124:30: error: ‘SmallVectorSizeType’ was not declared in this scope; did you mean ‘SmallVectorBase’? [-Wtemplate-body]
  124 |     : public SmallVectorBase<SmallVectorSizeType<T>> {
      |                              ^~~~~~~~~~~~~~~~~~~
      |                              SmallVectorBase
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:124:50: error: template argument 1 is invalid [-Wtemplate-body]
  124 |     : public SmallVectorBase<SmallVectorSizeType<T>> {
      |                                                  ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:124:51: error: expected ‘{’ before ‘>’ token
  124 |     : public SmallVectorBase<SmallVectorSizeType<T>> {
      |                                                   ^~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In member function ‘T* llvm::SmallVectorTemplateBase<T, <anonymous> >::mallocForGrow(size_t, size_t&)’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:447:23: error: ‘SmallVectorSizeType’ was not declared in this scope; did you mean ‘SmallVectorBase’? [-Wtemplate-body]
  447 |       SmallVectorBase<SmallVectorSizeType<T>>::mallocForGrow(
      |                       ^~~~~~~~~~~~~~~~~~~
      |                       SmallVectorBase
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:447:43: error: template argument 1 is invalid [-Wtemplate-body]
  447 |       SmallVectorBase<SmallVectorSizeType<T>>::mallocForGrow(
      |                                           ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:447:48: error: ‘::mallocForGrow’ has not been declared [-Wtemplate-body]
  447 |       SmallVectorBase<SmallVectorSizeType<T>>::mallocForGrow(
      |                                                ^~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: At global scope:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1321:45: error: ‘uint32_t’ was not declared in this scope
 1321 | extern template class llvm::SmallVectorBase<uint32_t>;
      |                                             ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1321:45: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1321:53: error: template argument 1 is invalid
 1321 | extern template class llvm::SmallVectorBase<uint32_t>;
      |                                                     ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘class llvm::SmallVectorTemplateBase<void*, true>’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:577:7:   required from ‘class llvm::SmallVectorImpl<void*>’
  577 | class SmallVectorImpl : public SmallVectorTemplateBase<T> {
      |       ^~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1199:22:   required from ‘class llvm::SmallVector<void*, 4>’
 1199 | class LLVM_GSL_OWNER SmallVector : public SmallVectorImpl<T>,
      |                      ^~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:311:26:   required from here
  311 |   SmallVector<void *, 4> Slabs;
      |                          ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:479:7: error: invalid use of incomplete type ‘class llvm::SmallVectorTemplateCommon<void*, void>’
  479 | class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:123:7: note: declaration of ‘class llvm::SmallVectorTemplateCommon<void*, void>’
  123 | class SmallVectorTemplateCommon
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘class llvm::SmallVectorImpl<void*>’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1199:22:   required from ‘class llvm::SmallVector<void*, 4>’
 1199 | class LLVM_GSL_OWNER SmallVector : public SmallVectorImpl<T>,
      |                      ^~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:311:26:   required from here
  311 |   SmallVector<void *, 4> Slabs;
      |                          ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:581:9: error: no type named ‘iterator’ in ‘using llvm::SmallVectorImpl<void*>::SuperClass = class llvm::SmallVectorTemplateBase<void*, true>’ {aka ‘class llvm::SmallVectorTemplateBase<void*, true>’}
  581 |   using iterator = typename SuperClass::iterator;
      |         ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:582:9: error: no type named ‘const_iterator’ in ‘using llvm::SmallVectorImpl<void*>::SuperClass = class llvm::SmallVectorTemplateBase<void*, true>’ {aka ‘class llvm::SmallVectorTemplateBase<void*, true>’}
  582 |   using const_iterator = typename SuperClass::const_iterator;
      |         ^~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:583:9: error: no type named ‘reference’ in ‘using llvm::SmallVectorImpl<void*>::SuperClass = class llvm::SmallVectorTemplateBase<void*, true>’ {aka ‘class llvm::SmallVectorTemplateBase<void*, true>’}
  583 |   using reference = typename SuperClass::reference;
      |         ^~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:584:9: error: no type named ‘size_type’ in ‘using llvm::SmallVectorImpl<void*>::SuperClass = class llvm::SmallVectorTemplateBase<void*, true>’ {aka ‘class llvm::SmallVectorTemplateBase<void*, true>’}
  584 |   using size_type = typename SuperClass::size_type;
      |         ^~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:621:21: error: ‘set_size’ has not been declared in ‘using llvm::SmallVectorImpl<void*>::SuperClass = class llvm::SmallVectorTemplateBase<void*, true>’
  621 |   using SuperClass::set_size;
      |                     ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:577:7:   required from ‘class llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >’
  577 | class SmallVectorImpl : public SmallVectorTemplateBase<T> {
      |       ^~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1199:22:   required from ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
 1199 | class LLVM_GSL_OWNER SmallVector : public SmallVectorImpl<T>,
      |                      ^~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:314:45:   required from here
  314 |   SmallVector<std::pair<void *, size_t>, 0> CustomSizedSlabs;
      |                                             ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:479:7: error: invalid use of incomplete type ‘class llvm::SmallVectorTemplateCommon<std::pair<void*, long unsigned int>, void>’
  479 | class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:123:7: note: declaration of ‘class llvm::SmallVectorTemplateCommon<std::pair<void*, long unsigned int>, void>’
  123 | class SmallVectorTemplateCommon
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘class llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1199:22:   required from ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
 1199 | class LLVM_GSL_OWNER SmallVector : public SmallVectorImpl<T>,
      |                      ^~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:314:45:   required from here
  314 |   SmallVector<std::pair<void *, size_t>, 0> CustomSizedSlabs;
      |                                             ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:581:9: error: no type named ‘iterator’ in ‘using llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >::SuperClass = class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’ {aka ‘class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’}
  581 |   using iterator = typename SuperClass::iterator;
      |         ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:582:9: error: no type named ‘const_iterator’ in ‘using llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >::SuperClass = class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’ {aka ‘class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’}
  582 |   using const_iterator = typename SuperClass::const_iterator;
      |         ^~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:583:9: error: no type named ‘reference’ in ‘using llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >::SuperClass = class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’ {aka ‘class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’}
  583 |   using reference = typename SuperClass::reference;
      |         ^~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:584:9: error: no type named ‘size_type’ in ‘using llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >::SuperClass = class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’ {aka ‘class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’}
  584 |   using size_type = typename SuperClass::size_type;
      |         ^~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:621:21: error: ‘set_size’ has not been declared in ‘using llvm::SmallVectorImpl<std::pair<void*, long unsigned int> >::SuperClass = class llvm::SmallVectorTemplateBase<std::pair<void*, long unsigned int>, true>’
  621 |   using SuperClass::set_size;
      |                     ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:351:59: error: expected ‘)’ before ‘,’ token [-Wtemplate-body]
  351 |   void DeallocateSlabs(SmallVectorImpl<void *>::iterator I,
      |                       ~                                   ^
      |                                                           )
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:352:24: error: invalid use of qualified-name ‘llvm::SmallVectorImpl<void*>::iterator’ [-Wtemplate-body]
  352 |                        SmallVectorImpl<void *>::iterator E) {
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:352:49: error: expected ‘;’ at end of member declaration [-Wtemplate-body]
  352 |                        SmallVectorImpl<void *>::iterator E) {
      |                                                 ^~~~~~~~
      |                                                         ;
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:352:58: error: ‘E’ does not name a type [-Wtemplate-body]
  352 |                        SmallVectorImpl<void *>::iterator E) {
      |                                                          ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In destructor ‘llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::~BumpPtrAllocatorImpl()’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:98:27: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
   98 |     DeallocateSlabs(Slabs.begin(), Slabs.end());
      |                           ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:98:42: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘end’ [-Wtemplate-body]
   98 |     DeallocateSlabs(Slabs.begin(), Slabs.end());
      |                                          ^~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>& llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::operator=(llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>&&)’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:103:27: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  103 |     DeallocateSlabs(Slabs.begin(), Slabs.end());
      |                           ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:103:42: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘end’ [-Wtemplate-body]
  103 |     DeallocateSlabs(Slabs.begin(), Slabs.end());
      |                                          ^~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘void llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::Reset()’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:128:15: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘empty’ [-Wtemplate-body]
  128 |     if (Slabs.empty())
      |               ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:133:28: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘front’ [-Wtemplate-body]
  133 |     CurPtr = (char *)Slabs.front();
      |                            ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:137:37: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  137 |     DeallocateSlabs(std::next(Slabs.begin()), Slabs.end());
      |                                     ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:137:53: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘end’ [-Wtemplate-body]
  137 |     DeallocateSlabs(std::next(Slabs.begin()), Slabs.end());
      |                                                     ^~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:138:11: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘erase’ [-Wtemplate-body]
  138 |     Slabs.erase(std::next(Slabs.begin()), Slabs.end());
      |           ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:138:33: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  138 |     Slabs.erase(std::next(Slabs.begin()), Slabs.end());
      |                                 ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:138:49: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘end’ [-Wtemplate-body]
  138 |     Slabs.erase(std::next(Slabs.begin()), Slabs.end());
      |                                                 ^~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘size_t llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::GetNumSlabs() const’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:225:45: error: ‘const class llvm::SmallVector<void*, 4>’ has no member named ‘size’ [-Wtemplate-body]
  225 |   size_t GetNumSlabs() const { return Slabs.size() + CustomSizedSlabs.size(); }
      |                                             ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:225:71: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘size’ [-Wtemplate-body]
  225 |   size_t GetNumSlabs() const { return Slabs.size() + CustomSizedSlabs.size(); }
      |                                                                       ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘std::optional<long int> llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::identifyObject(const void*)’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:235:36: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘size’ [-Wtemplate-body]
  235 |     for (size_t Idx = 0, E = Slabs.size(); Idx < E; Idx++) {
      |                                    ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:236:54: error: no match for ‘operator[]’ (operand types are ‘llvm::SmallVector<void*, 4>’ and ‘size_t’ {aka ‘long unsigned int’}) [-Wtemplate-body]
  236 |       const char *S = static_cast<const char *>(Slabs[Idx]);
      |                                                      ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:244:47: error: ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘size’ [-Wtemplate-body]
  244 |     for (size_t Idx = 0, E = CustomSizedSlabs.size(); Idx < E; Idx++) {
      |                                               ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:245:65: error: no match for ‘operator[]’ (operand types are ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ and ‘size_t’ {aka ‘long unsigned int’}) [-Wtemplate-body]
  245 |       const char *S = static_cast<const char *>(CustomSizedSlabs[Idx].first);
      |                                                                 ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:246:37: error: no match for ‘operator[]’ (operand types are ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ and ‘size_t’ {aka ‘long unsigned int’}) [-Wtemplate-body]
  246 |       size_t Size = CustomSizedSlabs[Idx].second;
      |                                     ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘size_t llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::getTotalMemory() const’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:283:25: error: ‘const class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  283 |     for (auto I = Slabs.begin(), E = Slabs.end(); I != E; ++I)
      |                         ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:283:56: error: ‘E’ was not declared in this scope [-Wtemplate-body]
  283 |     for (auto I = Slabs.begin(), E = Slabs.end(); I != E; ++I)
      |                                                        ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:284:58: error: ‘const class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  284 |       TotalMemory += computeSlabSize(std::distance(Slabs.begin(), I));
      |                                                          ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: error: no matching function for call to ‘begin(const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>&)’ [-Wtemplate-body]
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note: there are 6 candidates
In file included from /usr/include/c++/15.2.1/utility:75,
                 from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/type_traits.h:18,
                 from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:18:
/usr/include/c++/15.2.1/initializer_list:90:5: note: candidate 1: ‘template<class _Tp> constexpr const _Tp* std::begin(initializer_list<_Tp>)’
   90 |     begin(initializer_list<_Tp> __ils) noexcept
      |     ^~~~~
/usr/include/c++/15.2.1/initializer_list:90:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::initializer_list<_Tp>’
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
In file included from /usr/include/c++/15.2.1/unordered_map:44,
                 from /usr/include/c++/15.2.1/functional:65,
                 from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:24:
/usr/include/c++/15.2.1/bits/range_access.h:54:5: note: candidate 2: ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(_Container&)’
   54 |     begin(_Container& __cont) noexcept(noexcept(__cont.begin()))
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:54:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(_Container&) [with _Container = const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35:   required from here
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:55:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘begin’
   55 |     -> decltype(__cont.begin())
      |                 ~~~~~~~^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:66:5: note: candidate 3: ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(const _Container&)’
   66 |     begin(const _Container& __cont) noexcept(noexcept(__cont.begin()))
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:66:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(const _Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35:   required from here
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:67:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘begin’
   67 |     -> decltype(__cont.begin())
      |                 ~~~~~~~^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:101:5: note: candidate 4: ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::begin(_Tp (&)[_Nm])’
  101 |     begin(_Tp (&__arr)[_Nm]) noexcept
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:101:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   mismatched types ‘_Tp [_Nm]’ and ‘const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:119:31: note: candidate 5: ‘template<class _Tp> _Tp* std::begin(valarray<_Tp>&)’
  119 |   template<typename _Tp> _Tp* begin(valarray<_Tp>&) noexcept;
      |                               ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:119:31: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   types ‘std::valarray<_Tp>’ and ‘const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ have incompatible cv-qualifiers
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:120:37: note: candidate 6: ‘template<class _Tp> const _Tp* std::begin(const valarray<_Tp>&)’
  120 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
      |                                     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:120:37: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   ‘const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘const std::valarray<_Tp>’
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: error: no matching function for call to ‘end(const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>&)’ [-Wtemplate-body]
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note: there are 6 candidates
/usr/include/c++/15.2.1/initializer_list:101:5: note: candidate 1: ‘template<class _Tp> constexpr const _Tp* std::end(initializer_list<_Tp>)’
  101 |     end(initializer_list<_Tp> __ils) noexcept
      |     ^~~
/usr/include/c++/15.2.1/initializer_list:101:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::initializer_list<_Tp>’
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:78:5: note: candidate 2: ‘template<class _Container> constexpr decltype (__cont.end()) std::end(_Container&)’
   78 |     end(_Container& __cont) noexcept(noexcept(__cont.end()))
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:78:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.end()) std::end(_Container&) [with _Container = const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35:   required from here
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:79:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘end’
   79 |     -> decltype(__cont.end())
      |                 ~~~~~~~^~~
/usr/include/c++/15.2.1/bits/range_access.h:90:5: note: candidate 3: ‘template<class _Container> constexpr decltype (__cont.end()) std::end(const _Container&)’
   90 |     end(const _Container& __cont) noexcept(noexcept(__cont.end()))
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:90:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.end()) std::end(const _Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35:   required from here
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:91:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘end’
   91 |     -> decltype(__cont.end())
      |                 ~~~~~~~^~~
/usr/include/c++/15.2.1/bits/range_access.h:112:5: note: candidate 4: ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::end(_Tp (&)[_Nm])’
  112 |     end(_Tp (&__arr)[_Nm]) noexcept
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:112:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   mismatched types ‘_Tp [_Nm]’ and ‘const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:121:31: note: candidate 5: ‘template<class _Tp> _Tp* std::end(valarray<_Tp>&)’
  121 |   template<typename _Tp> _Tp* end(valarray<_Tp>&) noexcept;
      |                               ^~~
/usr/include/c++/15.2.1/bits/range_access.h:121:31: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   types ‘std::valarray<_Tp>’ and ‘const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ have incompatible cv-qualifiers
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:122:37: note: candidate 6: ‘template<class _Tp> const _Tp* std::end(const valarray<_Tp>&)’
  122 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
      |                                     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:122:37: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:285:35: note:   ‘const llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘const std::valarray<_Tp>’
  285 |     for (const auto &PtrAndSize : CustomSizedSlabs)
      |                                   ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘void llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::PrintStats() const’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:297:46: error: ‘const class llvm::SmallVector<void*, 4>’ has no member named ‘size’ [-Wtemplate-body]
  297 |     detail::printBumpPtrAllocatorStats(Slabs.size(), BytesAllocated,
      |                                              ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘void llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::StartNewSlab()’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:337:54: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘size’ [-Wtemplate-body]
  337 |     size_t AllocatedSlabSize = computeSlabSize(Slabs.size());
      |                                                      ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘void llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold, GrowthDelay>::DeallocateCustomSizedSlabs()’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: error: no matching function for call to ‘begin(llvm::SmallVector<std::pair<void*, long unsigned int>, 0>&)’ [-Wtemplate-body]
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note: there are 6 candidates
/usr/include/c++/15.2.1/initializer_list:90:5: note: candidate 1: ‘template<class _Tp> constexpr const _Tp* std::begin(initializer_list<_Tp>)’
   90 |     begin(initializer_list<_Tp> __ils) noexcept
      |     ^~~~~
/usr/include/c++/15.2.1/initializer_list:90:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::initializer_list<_Tp>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:54:5: note: candidate 2: ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(_Container&)’
   54 |     begin(_Container& __cont) noexcept(noexcept(__cont.begin()))
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:54:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(_Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29:   required from here
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:55:24: error: ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘begin’
   55 |     -> decltype(__cont.begin())
      |                 ~~~~~~~^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:66:5: note: candidate 3: ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(const _Container&)’
   66 |     begin(const _Container& __cont) noexcept(noexcept(__cont.begin()))
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:66:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(const _Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29:   required from here
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:67:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘begin’
   67 |     -> decltype(__cont.begin())
      |                 ~~~~~~~^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:101:5: note: candidate 4: ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::begin(_Tp (&)[_Nm])’
  101 |     begin(_Tp (&__arr)[_Nm]) noexcept
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:101:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   mismatched types ‘_Tp [_Nm]’ and ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:119:31: note: candidate 5: ‘template<class _Tp> _Tp* std::begin(valarray<_Tp>&)’
  119 |   template<typename _Tp> _Tp* begin(valarray<_Tp>&) noexcept;
      |                               ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:119:31: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::valarray<_Tp>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:120:37: note: candidate 6: ‘template<class _Tp> const _Tp* std::begin(const valarray<_Tp>&)’
  120 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
      |                                     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:120:37: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘const std::valarray<_Tp>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: error: no matching function for call to ‘end(llvm::SmallVector<std::pair<void*, long unsigned int>, 0>&)’ [-Wtemplate-body]
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note: there are 6 candidates
/usr/include/c++/15.2.1/initializer_list:101:5: note: candidate 1: ‘template<class _Tp> constexpr const _Tp* std::end(initializer_list<_Tp>)’
  101 |     end(initializer_list<_Tp> __ils) noexcept
      |     ^~~
/usr/include/c++/15.2.1/initializer_list:101:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::initializer_list<_Tp>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:78:5: note: candidate 2: ‘template<class _Container> constexpr decltype (__cont.end()) std::end(_Container&)’
   78 |     end(_Container& __cont) noexcept(noexcept(__cont.end()))
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:78:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.end()) std::end(_Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29:   required from here
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:79:24: error: ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘end’
   79 |     -> decltype(__cont.end())
      |                 ~~~~~~~^~~
/usr/include/c++/15.2.1/bits/range_access.h:90:5: note: candidate 3: ‘template<class _Container> constexpr decltype (__cont.end()) std::end(const _Container&)’
   90 |     end(const _Container& __cont) noexcept(noexcept(__cont.end()))
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:90:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.end()) std::end(const _Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29:   required from here
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:91:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘end’
   91 |     -> decltype(__cont.end())
      |                 ~~~~~~~^~~
/usr/include/c++/15.2.1/bits/range_access.h:112:5: note: candidate 4: ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::end(_Tp (&)[_Nm])’
  112 |     end(_Tp (&__arr)[_Nm]) noexcept
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:112:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   mismatched types ‘_Tp [_Nm]’ and ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:121:31: note: candidate 5: ‘template<class _Tp> _Tp* std::end(valarray<_Tp>&)’
  121 |   template<typename _Tp> _Tp* end(valarray<_Tp>&) noexcept;
      |                               ^~~
/usr/include/c++/15.2.1/bits/range_access.h:121:31: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::valarray<_Tp>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:122:37: note: candidate 6: ‘template<class _Tp> const _Tp* std::end(const valarray<_Tp>&)’
  122 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
      |                                     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:122:37: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:363:29: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘const std::valarray<_Tp>’
  363 |     for (auto &PtrAndSize : CustomSizedSlabs) {
      |                             ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h: In member function ‘void llvm::SpecificBumpPtrAllocator<T>::DestroyAll()’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:410:35: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  410 |     for (auto I = Allocator.Slabs.begin(), E = Allocator.Slabs.end(); I != E;
      |                                   ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:410:76: error: ‘E’ was not declared in this scope [-Wtemplate-body]
  410 |     for (auto I = Allocator.Slabs.begin(), E = Allocator.Slabs.end(); I != E;
      |                                                                            ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:413:41: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘begin’ [-Wtemplate-body]
  413 |           std::distance(Allocator.Slabs.begin(), I));
      |                                         ^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:415:41: error: ‘class llvm::SmallVector<void*, 4>’ has no member named ‘back’ [-Wtemplate-body]
  415 |       char *End = *I == Allocator.Slabs.back() ? Allocator.CurPtr
      |                                         ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: error: no matching function for call to ‘begin(llvm::SmallVector<std::pair<void*, long unsigned int>, 0>&)’ [-Wtemplate-body]
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note: there are 6 candidates
/usr/include/c++/15.2.1/initializer_list:90:5: note: candidate 1: ‘template<class _Tp> constexpr const _Tp* std::begin(initializer_list<_Tp>)’
   90 |     begin(initializer_list<_Tp> __ils) noexcept
      |     ^~~~~
/usr/include/c++/15.2.1/initializer_list:90:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::initializer_list<_Tp>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:54:5: note: candidate 2: ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(_Container&)’
   54 |     begin(_Container& __cont) noexcept(noexcept(__cont.begin()))
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:54:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(_Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39:   required from here
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:55:24: error: ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘begin’
   55 |     -> decltype(__cont.begin())
      |                 ~~~~~~~^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:66:5: note: candidate 3: ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(const _Container&)’
   66 |     begin(const _Container& __cont) noexcept(noexcept(__cont.begin()))
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:66:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.begin()) std::begin(const _Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39:   required from here
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:67:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘begin’
   67 |     -> decltype(__cont.begin())
      |                 ~~~~~~~^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:101:5: note: candidate 4: ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::begin(_Tp (&)[_Nm])’
  101 |     begin(_Tp (&__arr)[_Nm]) noexcept
      |     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:101:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   mismatched types ‘_Tp [_Nm]’ and ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:119:31: note: candidate 5: ‘template<class _Tp> _Tp* std::begin(valarray<_Tp>&)’
  119 |   template<typename _Tp> _Tp* begin(valarray<_Tp>&) noexcept;
      |                               ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:119:31: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::valarray<_Tp>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:120:37: note: candidate 6: ‘template<class _Tp> const _Tp* std::begin(const valarray<_Tp>&)’
  120 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
      |                                     ^~~~~
/usr/include/c++/15.2.1/bits/range_access.h:120:37: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘const std::valarray<_Tp>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: error: no matching function for call to ‘end(llvm::SmallVector<std::pair<void*, long unsigned int>, 0>&)’ [-Wtemplate-body]
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note: there are 6 candidates
/usr/include/c++/15.2.1/initializer_list:101:5: note: candidate 1: ‘template<class _Tp> constexpr const _Tp* std::end(initializer_list<_Tp>)’
  101 |     end(initializer_list<_Tp> __ils) noexcept
      |     ^~~
/usr/include/c++/15.2.1/initializer_list:101:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::initializer_list<_Tp>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:78:5: note: candidate 2: ‘template<class _Container> constexpr decltype (__cont.end()) std::end(_Container&)’
   78 |     end(_Container& __cont) noexcept(noexcept(__cont.end()))
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:78:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.end()) std::end(_Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39:   required from here
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:79:24: error: ‘class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘end’
   79 |     -> decltype(__cont.end())
      |                 ~~~~~~~^~~
/usr/include/c++/15.2.1/bits/range_access.h:90:5: note: candidate 3: ‘template<class _Container> constexpr decltype (__cont.end()) std::end(const _Container&)’
   90 |     end(const _Container& __cont) noexcept(noexcept(__cont.end()))
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:90:5: note: template argument deduction/substitution failed:
/usr/include/c++/15.2.1/bits/range_access.h: In substitution of ‘template<class _Container> constexpr decltype (__cont.end()) std::end(const _Container&) [with _Container = llvm::SmallVector<std::pair<void*, long unsigned int>, 0>]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39:   required from here
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:91:24: error: ‘const class llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ has no member named ‘end’
   91 |     -> decltype(__cont.end())
      |                 ~~~~~~~^~~
/usr/include/c++/15.2.1/bits/range_access.h:112:5: note: candidate 4: ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::end(_Tp (&)[_Nm])’
  112 |     end(_Tp (&__arr)[_Nm]) noexcept
      |     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:112:5: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   mismatched types ‘_Tp [_Nm]’ and ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:121:31: note: candidate 5: ‘template<class _Tp> _Tp* std::end(valarray<_Tp>&)’
  121 |   template<typename _Tp> _Tp* end(valarray<_Tp>&) noexcept;
      |                               ^~~
/usr/include/c++/15.2.1/bits/range_access.h:121:31: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘std::valarray<_Tp>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/bits/range_access.h:122:37: note: candidate 6: ‘template<class _Tp> const _Tp* std::end(const valarray<_Tp>&)’
  122 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
      |                                     ^~~
/usr/include/c++/15.2.1/bits/range_access.h:122:37: note: template argument deduction/substitution failed:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/Allocator.h:421:39: note:   ‘llvm::SmallVector<std::pair<void*, long unsigned int>, 0>’ is not derived from ‘const std::valarray<_Tp>’
  421 |     for (auto &PtrAndSize : Allocator.CustomSizedSlabs) {
      |                                       ^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘class llvm::SmallVectorTemplateBase<char, true>’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:577:7:   required from ‘class llvm::SmallVectorImpl<char>’
  577 | class SmallVectorImpl : public SmallVectorTemplateBase<T> {
      |       ^~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:244:28:   required from here
  244 |     return this->operator<<(StringRef(Str));
      |            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:479:7: error: invalid use of incomplete type ‘class llvm::SmallVectorTemplateCommon<char, void>’
  479 | class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:123:7: note: declaration of ‘class llvm::SmallVectorTemplateCommon<char, void>’
  123 | class SmallVectorTemplateCommon
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘class llvm::SmallVectorImpl<char>’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:244:28:   required from here
  244 |     return this->operator<<(StringRef(Str));
      |            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:581:9: error: no type named ‘iterator’ in ‘using llvm::SmallVectorImpl<char>::SuperClass = class llvm::SmallVectorTemplateBase<char, true>’ {aka ‘class llvm::SmallVectorTemplateBase<char, true>’}
  581 |   using iterator = typename SuperClass::iterator;
      |         ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:582:9: error: no type named ‘const_iterator’ in ‘using llvm::SmallVectorImpl<char>::SuperClass = class llvm::SmallVectorTemplateBase<char, true>’ {aka ‘class llvm::SmallVectorTemplateBase<char, true>’}
  582 |   using const_iterator = typename SuperClass::const_iterator;
      |         ^~~~~~~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:583:9: error: no type named ‘reference’ in ‘using llvm::SmallVectorImpl<char>::SuperClass = class llvm::SmallVectorTemplateBase<char, true>’ {aka ‘class llvm::SmallVectorTemplateBase<char, true>’}
  583 |   using reference = typename SuperClass::reference;
      |         ^~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:584:9: error: no type named ‘size_type’ in ‘using llvm::SmallVectorImpl<char>::SuperClass = class llvm::SmallVectorTemplateBase<char, true>’ {aka ‘class llvm::SmallVectorTemplateBase<char, true>’}
  584 |   using size_type = typename SuperClass::size_type;
      |         ^~~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:621:21: error: ‘set_size’ has not been declared in ‘using llvm::SmallVectorImpl<char>::SuperClass = class llvm::SmallVectorTemplateBase<char, true>’
  621 |   using SuperClass::set_size;
      |                     ^~~~~~~~
In file included from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Support/Allocator.cpp:14:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h: In member function ‘llvm::raw_ostream& llvm::raw_ostream::operator<<(const llvm::SmallVectorImpl<char>&)’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:257:22: error: ‘const class llvm::SmallVectorImpl<char>’ has no member named ‘data’
  257 |     return write(Str.data(), Str.size());
      |                      ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:257:34: error: ‘const class llvm::SmallVectorImpl<char>’ has no member named ‘size’
  257 |     return write(Str.data(), Str.size());
      |                                  ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h: In member function ‘llvm::StringRef llvm::raw_svector_ostream::str() const’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:697:47: error: ‘class llvm::SmallVectorImpl<char>’ has no member named ‘data’
  697 |   StringRef str() const { return StringRef(OS.data(), OS.size()); }
      |                                               ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:697:58: error: ‘class llvm::SmallVectorImpl<char>’ has no member named ‘size’
  697 |   StringRef str() const { return StringRef(OS.data(), OS.size()); }
      |                                                          ^~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h: In member function ‘virtual void llvm::raw_svector_ostream::reserveExtraSpace(uint64_t)’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:700:8: error: ‘class llvm::SmallVectorImpl<char>’ has no member named ‘reserve’
  700 |     OS.reserve(tell() + ExtraSize);
      |        ^~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h: In instantiation of ‘llvm::SmallVector<T, N>::~SmallVector() [with T = char; unsigned int N = 0]’:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/Support/raw_ostream.h:726:71:   required from here
  726 |   buffer_ostream(raw_ostream &OS) : raw_svector_ostream(Buffer), OS(OS) {}
      |                                                                       ^
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1206:31: error: ‘class llvm::SmallVector<char, 0>’ has no member named ‘begin’
 1206 |     this->destroy_range(this->begin(), this->end());
      |                         ~~~~~~^~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h:1206:46: error: ‘class llvm::SmallVector<char, 0>’ has no member named ‘end’
 1206 |     this->destroy_range(this->begin(), this->end());
      |                                        ~~~~~~^~~
make[3]: *** [lib/Support/CMakeFiles/LLVMSupport.dir/build.make:205: lib/Support/CMakeFiles/LLVMSupport.dir/Allocator.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:6779: lib/Support/CMakeFiles/LLVMSupport.dir/all] Error 2
make[1]: *** [Makefile:156: all] Error 2
make[1]: Leaving directory '/var/tmp/mrustc/rustc-1.74.0-src/build'
make: *** [minicargo.mk:292: rustc-1.74.0-src/build/bin/llvm-config] Error 2
```

#### llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
```
[ 69%] Building CXX object lib/Target/X86/MCTargetDesc/CMakeFiles/LLVMX86Desc.dir/X86EncodingOptimization.cpp.o
In file included from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h:19,
                 from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86EncodingOptimization.cpp:14:
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:86:50: error: ‘uint64_t’ has not been declared
   86 |                               int MemoryOperand, uint64_t TSFlags);
      |                                                  ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:18:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   17 | #include <string>
  +++ |+#include <cstdint>
   18 |
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:129:41: error: ‘uint32_t’ has not been declared
  129 | createX86MachObjectWriter(bool Is64Bit, uint32_t CPUType, uint32_t CPUSubtype);
      |                                         ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:129:41: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:129:59: error: ‘uint32_t’ has not been declared
  129 | createX86MachObjectWriter(bool Is64Bit, uint32_t CPUType, uint32_t CPUSubtype);
      |                                                           ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:129:59: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:133:40: error: ‘uint8_t’ has not been declared
  133 | createX86ELFObjectWriter(bool IsELF64, uint8_t OSABI, uint16_t EMachine);
      |                                        ^~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:133:40: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:133:55: error: ‘uint16_t’ has not been declared
  133 | createX86ELFObjectWriter(bool IsELF64, uint8_t OSABI, uint16_t EMachine);
      |                                                       ^~~~~~~~
/var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:133:55: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
In file included from /var/tmp/mrustc/rustc-1.74.0-src/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:152:
/var/tmp/mrustc/rustc-1.74.0-src/build/lib/Target/X86/X86GenRegisterInfo.inc:454:6: error: expected identifier before ‘:’ token
  454 | enum : uint16_t {
      |      ^
/var/tmp/mrustc/rustc-1.74.0-src/build/lib/Target/X86/X86GenRegisterInfo.inc:454:6: error: expected unqualified-id before ‘:’ token
make[3]: *** [lib/Target/X86/MCTargetDesc/CMakeFiles/LLVMX86Desc.dir/build.make:135: lib/Target/X86/MCTargetDesc/CMakeFiles/LLVMX86Desc.dir/X86EncodingOptimization.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:15548: lib/Target/X86/MCTargetDesc/CMakeFiles/LLVMX86Desc.dir/all] Error 2
make[1]: *** [Makefile:156: all] Error 2
make[1]: Leaving directory '/var/tmp/mrustc/rustc-1.74.0-src/build'
make: *** [minicargo.mk:292: rustc-1.74.0-src/build/bin/llvm-config] Error 2
```