### PR TITLE
target.cpp: enable 16-bit atomics on 32-bit powerpc

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -68,7 +68,7 @@ const TargetArch ARCH_POWERPC64LE = {
 const TargetArch ARCH_POWERPC = {
     "powerpc",
     32, true,
-    { /*atomic(u8)=*/true, false, true, false,  true },
+    { /*atomic(u8)=*/true, true, true, false,  true },
     TargetArch::Alignments(2, 4, 8, 8, 4, 8, 4)
 };
 const TargetArch ARCH_RISCV64 = {


### PR DESCRIPTION
Having it disabled breaks the build of `crossbeam-utils` 0.8.5+, enabling it fixes that – and does not seem to break anything else.
See also the discussion in attached issue.