### PR TITLE
Codegen - Apply `-fno-tree-sra` flag conditionally for GCC 15.1 and earlier

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1314,11 +1314,15 @@ namespace {
                     args.push_back("-O1");  // HACK: Work around mrustc #347 by reducing the optimisation level
                     break;
                 }
+#if defined(__GNUC__) && !defined(__clang__)
+#if __GNUC__ < 16 && !(__GNUC__ == 15 && __GNUC_MINOR__ > 1)
                 // HACK: Work around [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117423] by disabling an optimisation stage
                 if( opt.opt_level > 0 )
                 {
                     args.push_back("-fno-tree-sra");
                 }
+#endif
+#endif
                 if( opt.emit_debug_info )
                 {
                     args.push_back("-g");


### PR DESCRIPTION
The upstream bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117423 should be fixed for GCC 15.2 and later versions.
Though I have only tested the change with Clang 22.1.3 so it's possible the flag is still required as a workaround for other GCC bugs.

Fixes https://github.com/thepowersgang/mrustc/issues/368

