### PR TITLE
Codegen - Apply `-fno-delete-null-pointer-checks` flag for Clang

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1323,6 +1323,13 @@ namespace {
                 }
 #endif
 #endif
+#if defined(__clang__)
+                // https://github.com/thepowersgang/mrustc/issues/388#issuecomment-3920956315
+                if( opt.opt_level > 0 )
+                {
+                    args.push_back("-fno-delete-null-pointer-checks");
+                }
+#endif
                 if( opt.emit_debug_info )
                 {
                     args.push_back("-g");


### PR DESCRIPTION
I've tried the flag `-fno-delete-null-pointer-checks` which was suggested in https://github.com/thepowersgang/mrustc/issues/388#issuecomment-3920956315 and it fixes the segfault when running the stage0 cargo binary. The other flag `-fno-strict-return` didn't change anything.
Tested with Clang and `-O1` / `-O3` on `x86_64-linux-musl` (Gentoo Linux).

```bash
Completed cargo v0.91.0
 (99.7% 0r,0w,1b,371c/372t):
--- BUILDING cargo v0.91.0 [bin cargo] (99.7% 1r,0w,0b,371c/372t)
> /usr/lib/rust/mrustc-9999/bin/mrustc /var/tmp/portage/dev-lang/rust-1.90.0-r1/work/rustc-1.90.0-src/src/tools/cargo/src/bin/cargo/main.rs -o /var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/cargo -C emit-depfile=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/cargo.d --cfg debug_assertions -O -L /usr/lib/rust/mrustc-9999/lib/rustlib/x86_64-unknown-linux-musl/lib -L /var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build --cfg feature="http-transport-curl" --cfg feature="gix" --cfg feature="dep:gix" --crate-name cargo --crate-type bin --crate-tag 0_91_0_H102000000 --extern cargo=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcargo-0_91_0_H102000000.rlib --edition 2024 --extern annotate_snippets=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libannotate_snippets-0_11_5.rlib --extern anstream=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libanstream-0_6_19_H4010.rlib --extern anstyle=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libanstyle-1_0_11_H2.rlib --extern anyhow=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libanyhow-1_0_98_H8.rlib --extern base64=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libbase64-0_22_1_H81.rlib --extern blake3=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libblake3-1_8_2_H4000000.rlib --extern cargo_credential=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcargo_credential-0_4_8.rlib --extern cargo_platform=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcargo_platform-0_3_1.rlib --extern cargo_util_schemas=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcargo_util_schemas-0_10_0.rlib --extern cargo_util=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcargo_util-0_2_23.rlib --extern clap=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libclap-4_5_41_H31050c28.rlib --extern clap_complete=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libclap_complete-4_5_55_H802.rlib --extern color_print=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcolor_print-0_3_7.rlib --extern crates_io=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcrates_io-0_40_13.rlib --extern curl=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcurl-0_4_48_H2060a.rlib --extern curl_sys=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcurl_sys-0_4_82_H8114.rlib --extern filetime=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libfiletime-0_2_25.rlib --extern flate2=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libflate2-1_1_2_H20043.rlib --extern git2=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libgit2-0_20_2_H1d4.rlib --extern git2_curl=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libgit2_curl-0_21_0.rlib --extern gix=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libgix-0_73_0_H10220009002e4190.rlib --extern glob=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libglob-0_3_2.rlib --extern hex=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libhex-0_4_3_H81.rlib --extern hmac=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libhmac-0_12_1_H8.rlib --extern home=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libhome-0_5_11.rlib --extern http_auth=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libhttp_auth-0_1_10.rlib --extern ignore=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libignore-0_4_23.rlib --extern im_rc=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libim_rc-15_1_0.rlib --extern indexmap=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libindexmap-2_10_0_H800.rlib --extern itertools=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libitertools-0_14_0_Hc2.rlib --extern jiff=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libjiff-0_2_15_Hec814001.rlib --extern jobserver=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libjobserver-0_1_33.rlib --extern lazycell=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/liblazycell-1_3_0.rlib --extern libgit2_sys=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/liblibgit2_sys-0_18_2_Haa.rlib --extern memchr=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libmemchr-2_7_5_H101.rlib --extern opener=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libopener-0_8_2.rlib --extern os_info=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libos_info-3_12_0.rlib --extern pasetors=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libpasetors-0_7_6_H6bbf2.rlib --extern pathdiff=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libpathdiff-0_2_3.rlib --extern rand=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/librand-0_9_2_Hf051.rlib --extern regex=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libregex-1_11_1_H1ff6ef00.rlib --extern rusqlite=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/librusqlite-0_36_0_H108000040.rlib --extern rustc_hash=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/librustc_hash-2_1_1_H4.rlib --extern rustc_stable_hash=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/librustc_stable_hash-0_1_2.rlib --extern rustfix=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/librustfix-0_9_2.rlib --extern same_file=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libsame_file-1_0_6.rlib --extern semver=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libsemver-1_0_26_H3.rlib --extern serde=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libserde-1_0_219_H1b.rlib --extern serde_untagged=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libserde_untagged-0_1_7.rlib --extern serde_ignored=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libserde_ignored-0_1_12.rlib --extern serde_json=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libserde_json-1_0_141_H22280.rlib --extern sha1=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libsha1-0_10_6_H414.rlib --extern shell_escape=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libshell_escape-0_1_5.rlib --extern supports_hyperlinks=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libsupports_hyperlinks-3_1_0.rlib --extern supports_unicode=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libsupports_unicode-3_0_0.rlib --extern tar=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtar-0_4_44.rlib --extern tempfile=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtempfile-3_20_0_H4.rlib --extern thiserror=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libthiserror-2_0_12_H8.rlib --extern time=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtime-0_3_41_H108100d.rlib --extern toml=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtoml-0_9_2_H4a708.rlib --extern toml_edit=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtoml_edit-0_23_2_H40a8.rlib --extern tracing=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtracing-0_1_41_H380002.rlib --extern tracing_subscriber=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtracing_subscriber-0_3_19_H59e6e33.rlib --extern unicase=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libunicase-2_8_1.rlib --extern unicode_width=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libunicode_width-0_2_1_H1.rlib --extern unicode_xid=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libunicode_xid-0_2_6.rlib --extern url=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/liburl-2_5_4_H138.rlib --extern walkdir=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libwalkdir-2_5_0.rlib --extern tracing_chrome=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libtracing_chrome-0_7_2.rlib --extern cargo_credential_libsecret=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/libcargo_credential_libsecret-0_5_1.rlib --extern libc=/var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/liblibc-0_2_174_H20.rlib > /var/tmp/portage/dev-lang/rust-1.90.0-r1/work/bootstrap/mrustc-stage0/cargo-build/cargo_dbg.txt
 (99.7% 1r,0w,0b,371c/372t): cargo v0.91.0 [bin cargo]
Completed cargo v0.91.0 [bin cargo]
 (100.0% 0r,0w,0b,372c/372t):
/var/tmp/portage/dev-lang/rust-1.90.0-r1/temp/environment: line 2456:  2632 Segmentation fault         "${stage0}"/cargo-build/cargo --version
 ```