### PR TITLE
standalone_miri: add missing <cstdint> includes (follow-up to #360)

### DIFF
--- a/tools/standalone_miri/debug.cpp
+++ b/tools/standalone_miri/debug.cpp
@@ -6,6 +6,7 @@
  * - Interpreter debug logging
  */
 #include "debug.hpp"
+#include <cstdint>
 #include <fstream>
 #include "../../src/common.hpp" // FmtEscaped
 

--- a/tools/standalone_miri/hir_sim.hpp
+++ b/tools/standalone_miri/hir_sim.hpp
@@ -6,6 +6,7 @@
  * - Clones of the mrustc HIR types (HEADER)
  */
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>

--- a/tools/standalone_miri/lex.hpp
+++ b/tools/standalone_miri/lex.hpp
@@ -6,6 +6,7 @@
  * - Simple lexer for MIR files (HEADER)
  */
 #pragma once
+#include <cstdint>
 #include <string>
 #include <fstream>
 #include "../include/int128.h"

--- a/tools/standalone_miri/miri.hpp
+++ b/tools/standalone_miri/miri.hpp
@@ -6,6 +6,7 @@
  * - MIR Interpreter State (HEADER)
  */
 #pragma once
+#include <cstdint>
 #include "module_tree.hpp"
 #include "value.hpp"
 

--- a/tools/standalone_miri/module_tree.hpp
+++ b/tools/standalone_miri/module_tree.hpp
@@ -6,6 +6,7 @@
  * - In-memory representation of a Monomorphised MIR executable (HEADER)
  */
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
This is necessary for compiling with GCC 15 / libstdc++ 15, where the historical transitive inclusion of <cstdint> through other STL headers (<string>, <vector>, <memory>, ...) is being removed; uses of uint*_t / int*_t / uintptr_t must now name <cstdint> explicitly.

PR #360 already did the same sweep for src/ and tools/minicargo/, but the standalone_miri tree was missed. Without this, both the headers and debug.cpp fail to compile on ALT Sisyphus (GCC 15.x) and rawhide-like toolchains with errors of the form
"'uintptr_t' was not declared in this scope".

Link: https://github.com/thepowersgang/mrustc/pull/360
Link: https://gcc.gnu.org/gcc-15/porting_to.html