### PR TITLE
minicargo: exit 0 on --help

### DIFF
--- a/tools/minicargo/main.cpp
+++ b/tools/minicargo/main.cpp
@@ -385,7 +385,7 @@ int ProgramOptions::parse(int argc, const char* argv[])
                 break;
             case 'h':
                 this->help();
-                exit(1);
+                exit(0);
             default:
                 ::std::cerr << "Unknown flag -" << arg[1] << ::std::endl;
                 return 1;
@@ -400,7 +400,7 @@ int ProgramOptions::parse(int argc, const char* argv[])
             // Long arguments
             if( ::std::strcmp(arg, "--help") == 0 ) {
                 this->help();
-                exit(1);
+                exit(0);
             }
             else if( ::std::strcmp(arg, "--script-overrides") == 0 ) {
                 if(i+1 == argc) {


### PR DESCRIPTION
This is necessary to make `minicargo --help` follow the universal CLI convention: a help request is not an error and should yield status 0. cargo, rustc, gcc, clang, git, GNU coreutils all do this. The two sibling tools in this same repository already do it too — mrustc's own `--help` and standalone_miri's `--help` both exit(0); only minicargo was out of line, which made shells running with `set -e` (notably rpm %check and similar packaging smoke tests) abort on what should be a no-op invocation.