### PR TITLE
minicargo.mk: skip download/extract when rustc source dir exists

### DIFF
--- a/minicargo.mk
+++ b/minicargo.mk
@@ -217,7 +217,17 @@ bin/testrunner$(EXESUF):
 #
 # rustc (with std/cargo) source download
 #
+# If $(RUSTCSRC) (the extracted source directory) already exists, skip both the
+# download and extract steps -- this lets distro packagers / offline builds
+# pre-populate the tree from any source (.tar.zst, git checkout, ...) without
+# having to forge stamps. The patch step still runs unless its stamp is present.
 RUSTC_SRC_TARBALL := rustc-$(RUSTC_VERSION)-src.tar.gz
+ifneq ($(wildcard $(RUSTCSRC)),)
+# Pre-extracted source tree detected: no tarball needed, just touch the stamp.
+rustc-$(RUSTC_VERSION)-src/extracted:
+	@echo "[SKIP] extract (using pre-extracted $(RUSTCSRC))"
+	@touch $@
+else
 $(RUSTC_SRC_TARBALL):
 	@echo [CURL] $@
 	@rm -f $@
@@ -225,6 +235,7 @@ $(RUSTC_SRC_TARBALL):
 rustc-$(RUSTC_VERSION)-src/extracted: $(RUSTC_SRC_TARBALL)
 	tar -xzf $(RUSTC_SRC_TARBALL)
 	touch $@
+endif
 $(RUSTC_SRC_DL): rustc-$(RUSTC_VERSION)-src/extracted rustc-$(RUSTC_VERSION)-src.patch
 	cd $(RUSTCSRC) && patch -p0 < ../rustc-$(RUSTC_VERSION)-src.patch;
 	touch $@


### PR DESCRIPTION
Previously, even if the rustc-X.Y.Z-src/ tree was already populated by hand (distro packagers extracting from .tar.zst, a git checkout, etc.), make would still try to curl rustc-X.Y.Z-src.tar.gz from static.rust-lang.org and then re-extract it. This made offline / sandboxed builds (ALT Linux hasher, Nix, Guix, ...) require forging empty backdated tarballs and stamp files just to trick make into skipping the steps.

Detect a pre-existing source directory at parse time with $(wildcard ...) and, in that case, replace the extract recipe with a no-op that just touches the stamp. The download recipe is dropped from this branch entirely since nothing depends on it anymore. The normal download-driven flow is preserved verbatim when the directory is absent.

The patch step (rustc-X.Y.Z-src.patch -> dl-version stamp) is left alone: if the packager has already applied the patch, they can touch the dl-version stamp themselves; otherwise it runs as before. This matches the existing stamp-driven model.