### PR TITLE
Enable 16/64-bit atomics on x86 and gate equal_alignment by natural alignment

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -32,7 +32,8 @@ const TargetArch ARCH_X32 = {
 const TargetArch ARCH_X86 = {
     "x86",
     32, false,
-    { /*atomic(u8)=*/true, false, true, false,  true },
+    // i586+ baseline: 8/16/32-bit atomics via LOCK prefix, 64-bit via cmpxchg8b
+    { /*atomic(u8)=*/true, /*u16=*/true, /*u32=*/true, /*u64=*/true,  /*ptr=*/true },
     TargetArch::Alignments(2, 4, /*u64*/4, /*u128*/4, 4, 4, /*ptr*/4)    // u128 has the same alignment as u64, which is u32's alignment. And f64 is 4 byte aligned
 };
 const TargetArch ARCH_ARM64 = {

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -732,11 +732,15 @@ void Target_SetCfg(const ::std::string& target_name)
     Cfg_SetValue("target_endian", g_target.m_arch.m_big_endian ? "big" : "little");
     Cfg_SetValue("target_arch", g_target.m_arch.m_name);
     Cfg_SetValue("target_abi", "llvm"); // This is a lie, but hopefully works?
+    // target_has_atomic_equal_alignment="N" means align_of::<AtomicN>() == align_of::<N>().
+    // Since libcore declares AtomicN with repr(align(sizeof(N))), only set it when the
+    // primitive's natural alignment already matches its size (e.g. u64 on x86 has align 4,
+    // so target_has_atomic_equal_alignment="64" must be unset there even with cmpxchg8b).
     if(g_target.m_arch.m_atomics.u8)    { Cfg_SetValue("target_has_atomic", "8"  ); Cfg_SetValue("target_has_atomic_load_store", "8"  ); Cfg_SetValue("target_has_atomic_equal_alignment", "8"  ); }
-    if(g_target.m_arch.m_atomics.u16)   { Cfg_SetValue("target_has_atomic", "16" ); Cfg_SetValue("target_has_atomic_load_store", "16" ); Cfg_SetValue("target_has_atomic_equal_alignment", "16" ); }
-    if(g_target.m_arch.m_atomics.u32)   { Cfg_SetValue("target_has_atomic", "32" ); Cfg_SetValue("target_has_atomic_load_store", "32" ); Cfg_SetValue("target_has_atomic_equal_alignment", "32"); }
-    if(g_target.m_arch.m_atomics.u64)   { Cfg_SetValue("target_has_atomic", "64" ); Cfg_SetValue("target_has_atomic_load_store", "64" ); Cfg_SetValue("target_has_atomic_equal_alignment", "64"); }
-    if(g_target.m_arch.m_atomics.ptr)   { Cfg_SetValue("target_has_atomic", "ptr"); Cfg_SetValue("target_has_atomic_load_store", "ptr"); Cfg_SetValue("target_has_atomic_equal_alignment", "ptr"); }
+    if(g_target.m_arch.m_atomics.u16)   { Cfg_SetValue("target_has_atomic", "16" ); Cfg_SetValue("target_has_atomic_load_store", "16" ); if(g_target.m_arch.m_alignments.u16 >= 2) Cfg_SetValue("target_has_atomic_equal_alignment", "16" ); }
+    if(g_target.m_arch.m_atomics.u32)   { Cfg_SetValue("target_has_atomic", "32" ); Cfg_SetValue("target_has_atomic_load_store", "32" ); if(g_target.m_arch.m_alignments.u32 >= 4) Cfg_SetValue("target_has_atomic_equal_alignment", "32" ); }
+    if(g_target.m_arch.m_atomics.u64)   { Cfg_SetValue("target_has_atomic", "64" ); Cfg_SetValue("target_has_atomic_load_store", "64" ); if(g_target.m_arch.m_alignments.u64 >= 8) Cfg_SetValue("target_has_atomic_equal_alignment", "64" ); }
+    if(g_target.m_arch.m_atomics.ptr)   { Cfg_SetValue("target_has_atomic", "ptr"); Cfg_SetValue("target_has_atomic_load_store", "ptr"); if(g_target.m_arch.m_alignments.ptr * 8u >= g_target.m_arch.m_pointer_bits) Cfg_SetValue("target_has_atomic_equal_alignment", "ptr"); }
     // TODO: Atomic compare-and-set option
     if(g_target.m_arch.m_atomics.ptr)   { Cfg_SetValue("target_has_atomic", "cas");  }
     Cfg_SetValueCb("target_feature", [](const ::std::string& s) {


### PR DESCRIPTION
Two related fixes to `src/trans/target.cpp` surfaced when bootstrapping rustc 1.90.0 on i586:

1. **Enable 16/64-bit atomics for x86 (i586+).** `ARCH_X86` previously advertised only u8/u32/ptr, so `target_has_atomic_load_store` never gated `AtomicI16`/`AtomicU16` and the 64-bit pair into libcore. Crates that import them at bootstrap time (e.g. crossbeam-utils) then fail to resolve. i586+ has native 8/16/32-bit atomics via the `LOCK` prefix and 64-bit via `cmpxchg8b`, matching rustc's `i586-unknown-linux-gnu` target spec (`max_atomic_width = 64`).

2. **Gate `target_has_atomic_equal_alignment` on natural alignment.** With u64 atomics now reachable on x86, `align_of::<u64>` stays 4 while `AtomicU64` is `repr(align(8))`. libcore's `[(); align_of::<Self>() - align_of::<\$int>()]` assertion is guarded by this cfg and fires when the cfg is set wrongly. The cfg now follows the per-arch alignment data so naturally-aligned platforms (x86_64, aarch64, arm, ...) keep the flag while over-aligned cases (x86 u64, x32 u64) drop it.