### PR TITLE
hir: Fix ConstGeneric_Unevaluated::ord for populated-MIR pairs

### DIFF
--- a/src/hir/hir.cpp
+++ b/src/hir/hir.cpp
@@ -112,7 +112,7 @@ namespace HIR {
     {
         if( this->expr.get() != x.expr.get() ) {
             // If only one has populated MIR, they can't be equal (sort populated MIR after)
-            if( !this->expr->m_mir != !this->expr->m_mir ) {
+            if( !this->expr->m_mir != !x.expr->m_mir ) {
                 return (this->expr->m_mir ? OrdGreater : OrdLess);
             }
 

--- a/src/hir/hir.cpp
+++ b/src/hir/hir.cpp
@@ -126,18 +126,12 @@ namespace HIR {
                 return ::ord(tn->m_binding, xn->m_binding);
             }
 
-            // If the MIR is populated
-            if( this->expr->m_mir )
-            {
-                TODO(Span(), "Compare non-expanded array sizes - (w/ MIR) " << *this << " and " << x);
-            }
-            else {
-                // EVIL OPTION: Just compare the string representations
-                // - Hopefully there's no pointers printed involved.
-                auto v_t = FMT(*this);
-                auto v_x = FMT(x);
-                return ::ord(v_t, v_x);
-            }
+            // EVIL OPTION: Just compare the string representations
+            // - The fmt() routine prints MIR blocks (when populated) or the source expression
+            //   (when not) in a deterministic, pointer-free form, so this gives a stable order.
+            auto v_t = FMT(*this);
+            auto v_x = FMT(x);
+            return ::ord(v_t, v_x);
         }
         if(auto cmp = this->params_impl.ord(x.params_impl)) return cmp;
         if(auto cmp = this->params_item.ord(x.params_item)) return cmp;


### PR DESCRIPTION
Two small fixes to `ConstGeneric_Unevaluated::ord` in `src/hir/hir.cpp`, both observed bootstrapping rustc 1.90.0 libcore on aarch64 where pointer-width / SIMD const-generic array sizes first produce non-trivial Unevaluated pairs:

1. **Typo on the mixed-MIR arm.** The "only one side has populated MIR" branch compared `!this->expr->m_mir` against itself instead of `x.expr->m_mir`, so the condition was always false and mixed pairs fell through to the TODO abort.

2. **Drop the populated-MIR TODO.** When both sides carry MIR, fall through to the same string-compare fallback the no-MIR arm uses. `fmt()` dumps MIR deterministically and pointer-free, so this gives a stable total order without needing a real const-eval comparison.