### PR TITLE
hir_expand/static_borrow: Handle Defer and array-literal elements in lifted statics

### DIFF
--- a/src/hir_conv/constant_evaluation.cpp
+++ b/src/hir_conv/constant_evaluation.cpp
@@ -28,7 +28,7 @@ namespace {
     void ConvertHIR_ConstantEvaluate_Static(const ::HIR::Crate& crate, const ::HIR::GenericParams* impl_params, const ::HIR::ItemPath& ip, ::HIR::Static& e);
     void ConvertHIR_ConstantEvaluate_FcnSig(const ::HIR::Crate& crate, const ::HIR::GenericParams* impl_params, const ::HIR::ItemPath& ip, ::HIR::Function& fcn);
 
-    struct Defer {};
+    using HIR::Defer;
 
     struct NewvalState
         : public HIR::Evaluator::Newval

--- a/src/hir_conv/constant_evaluation.hpp
+++ b/src/hir_conv/constant_evaluation.hpp
@@ -16,6 +16,12 @@ namespace MIR {
 
 namespace HIR {
 
+// Thrown by Evaluator::evaluate_constant when some dependency of the
+// constant being evaluated is itself not yet resolved (typically still a
+// generic parameter or an inferred type). Callers outside this module are
+// expected to catch and treat as "leave for a later pass to retry".
+struct Defer {};
+
 struct Evaluator
 {
     class Newval

--- a/src/hir_expand/static_borrow_constants.cpp
+++ b/src/hir_expand/static_borrow_constants.cpp
@@ -910,7 +910,23 @@ namespace static_borrow_constants {
             } v(resolve, monomorph);
             node->visit(v);
             v.visit_type(node->m_res_type);
-            if( !v.is_generic ) {
+            // `is_generic` is set by the targeted visit overrides above
+            // (ExprNode_ConstParam, ExprNode_ArraySized) plus visit_type /
+            // visit_path_params. Those reliably cover type- and lifetime-
+            // generic references, but a const-generic value param can still
+            // leak through paths not yet enumerated -- e.g. ARM Neon's
+            // `core_arch::arm_shared::neon::generated` lifted const blocks
+            // hit `_ = Constant(N/*M:0*/)` in MIR with the surrounding
+            // method's `const N: i32` never remapped, then assert in
+            // MonomorphiserPP::get_value because the lifted static was
+            // wiped to a concrete (empty params) item. Preserve the params
+            // whenever the source context carries any const-generic value
+            // param: the only cost is a slightly later (Trans Monomorph)
+            // evaluation instead of an SBC-time concrete one.
+            bool has_value_generics =
+                   !m_resolve.impl_generics().m_values.empty()
+                || !m_resolve.item_generics().m_values.empty();
+            if( !v.is_generic && !has_value_generics ) {
                 params_def = HIR::GenericParams();
                 constr_params = HIR::PathParams();
                 DEBUG("Concrete static");

--- a/src/hir_expand/static_borrow_constants.cpp
+++ b/src/hir_expand/static_borrow_constants.cpp
@@ -1159,8 +1159,16 @@ namespace static_borrow_constants {
                     if( !new_static.m_params.is_generic() )
                     {
                         new_static.m_value.m_state->stage = ::HIR::ExprState::Stage::Sbc;
-                        new_static.m_value_res = ::HIR::Evaluator(sp, m_crate, nvs).evaluate_constant( new_static_pair.path, new_static.m_value, new_static.m_type.clone());
-                        new_static.m_value_generated = true;
+                        try {
+                            new_static.m_value_res = ::HIR::Evaluator(sp, m_crate, nvs).evaluate_constant( new_static_pair.path, new_static.m_value, new_static.m_type.clone());
+                            new_static.m_value_generated = true;
+                        }
+                        catch(const ::HIR::Defer&) {
+                            // A dependency is not fully resolved yet; leave the
+                            // extracted static value as not-generated and let the
+                            // subsequent passes pick it up rather than aborting.
+                            DEBUG("Deferred static borrow eval: " << new_static_pair.path);
+                        }
                     }
 
                     struct H {
@@ -1402,8 +1410,13 @@ void HIR_Expand_StaticBorrowConstants_Expr(const ::HIR::Crate& crate, const ::HI
         if( !new_static.m_params.is_generic() )
         {
             new_static.m_value.m_state->stage = ::HIR::ExprState::Stage::Sbc;
-            new_static.m_value_res = ::HIR::Evaluator(sp, crate, nvs).evaluate_constant( path, new_static.m_value, new_static.m_type.clone());
-            new_static.m_value_generated = true;
+            try {
+                new_static.m_value_res = ::HIR::Evaluator(sp, crate, nvs).evaluate_constant( path, new_static.m_value, new_static.m_type.clone());
+                new_static.m_value_generated = true;
+            }
+            catch(const ::HIR::Defer&) {
+                DEBUG("Deferred static borrow eval: " << path);
+            }
         }
 
         DEBUG(path << " = ?");

--- a/src/hir_expand/static_borrow_constants.cpp
+++ b/src/hir_expand/static_borrow_constants.cpp
@@ -898,6 +898,7 @@ namespace static_borrow_constants {
                     is_generic = true;
                 }
                 void visit(HIR::ExprNode_ArraySized& node) override {
+                    HIR::ExprVisitorDef::visit(node);
                     if( auto* n = node.m_size.opt_Unevaluated() )
                     {
                         if( auto* g = n->opt_Generic() )


### PR DESCRIPTION
Two fixes to the Static Borrow Constants pass in
`src/hir_expand/static_borrow_constants.cpp`, both surfaced while bootstrapping
rustc 1.90.0 libcore for `aarch64-unknown-linux-gnu`.

## 1. Catch `HIR::Defer` from the extracted-static const-eval

The evaluator throws `Defer` when a dependency of the constant being evaluated
is not resolved yet, but the two SBC call sites of `evaluate_constant` had no
`try`/`catch`, so a deferred evaluation propagated to `std::terminate`.

Handle it the way `Constant Evaluate` already does: leave the new static's
value as not-yet-generated and let a later pass retry. This required promoting
the previously anonymous-namespace `Defer` into `namespace HIR` (a new
declaration in `src/hir_conv/constant_evaluation.hpp`) so out-of-module passes
can catch it.

## 2. Visit the element of a sized-array literal

`extract_node`'s visitor overrode `visit(HIR::ExprNode_ArraySized&)` in order
to remap a const-generic array *size*, but never chained to
`HIR::ExprVisitorDef::visit(node)`. The repeated element expression
(`node.m_val`) was therefore never visited at all.

Consequences for `[val; N]` when `val` mentions a const-generic:

* `is_generic` stayed clear, so `extract_node` wiped `params_def` and
  `constr_params` and emitted the lifted item as concrete;
* the `ExprNode_ConstParam` inside `val` never had its binding remapped into
  the new item's parameter space;
* `visit_type` was never applied to the element's result type.

Trans Monomorph then asserts:

```
BUG: ASSERT FAIL: src/hir_typeck/common.cpp:721:val.idx() < p->m_values.size():
  Value param N/*M:0*/ out of range for (max 0)
```

on `::"core-0_0_0"::core_arch::arm_shared::neon::generated::lifted#915`, whose
MIR is a bare `_0 = Constant(N/*M:0*/)`. The source is stdarch's aarch64 neon
intrinsics, e.g.

```rust
pub fn vqshlu_n_s8<const N: i32>(a: int8x8_t) -> uint8x8_t {
    static_assert_uimm_bits!(N, 3);
    unsafe { _vqshlu_n_s8(a, const { int8x8_t([N as i8; 8]) }) }
}
```

The fix is to call the base visitor first; `ExprVisitorDef` deliberately does
not descend into the array *size*, which is why the existing size handling
stays as it is.

## Testing

* `make -f minicargo.mk LIBS RUSTC_VERSION=1.90.0 MRUSTC_TARGET=aarch64-unknown-linux-gnu`
  — libcore/liballoc/libstd now get through every HIR and MIR pass (the run
  still stops at the cross C compile, which is a host-toolchain limitation,
  not an mrustc one).
* `make -f minicargo.mk LIBS RUSTC_VERSION=1.90.0` (host x86_64) — full
  standard library builds.
* `make -f minicargo.mk local_tests RUSTC_VERSION=1.90.0` — 30 passed,
  0 failed.

Note: with fix 2 in place, plain upstream + fix 2 no longer needs fix 1 to
build the 1.90.0 aarch64 library set. Fix 1 is kept as the defensive change it
is — `Defer` escaping to `std::terminate` is never the right outcome.
