### PR TITLE
trans/codegen_c: Collapse Rust asm! double-dollar escape for GCC inline asm

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -5618,11 +5618,33 @@ namespace {
                 if( (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.options.att_syntax )
                     m_of << ".intel_syntax noprefix; ";
                 bool escape_percent = true || !inputs.empty() || !outputs.empty();
+                // Rust's `asm!` templates are passed verbatim to LLVM, where `$$`
+                // is the escape for a literal `$` (LLVM IR uses `$N` for operand
+                // references). The GCC inline-asm backend has no such escape, and
+                // a stray `$` survives into the GAS input as e.g. `int $0x80` —
+                // which GAS rejects in `.intel_syntax noprefix` mode with
+                // "operand type mismatch". Collapse `$$` here: drop it entirely
+                // for Intel-syntax blocks (so `int $$0x80` -> `int 0x80`), and
+                // halve it for AT&T blocks (so the immediate prefix survives).
+                auto xlat_dollars = [&](const std::string& s) {
+                    std::string r;
+                    r.reserve(s.size());
+                    for(size_t i = 0; i < s.size(); ++i) {
+                        if(s[i] == '$' && i+1 < s.size() && s[i+1] == '$') {
+                            if(se.options.att_syntax) r += '$';
+                            i++;
+                        }
+                        else {
+                            r += s[i];
+                        }
+                    }
+                    return r;
+                };
                 for(const auto& l : se.lines)
                 {
                     for(const auto& f : l.frags)
                     {
-                        m_of << FmtGccAsm(f.before, escape_percent);
+                        m_of << FmtGccAsm(xlat_dollars(f.before), escape_percent);
                         MIR_ASSERT(mir_res, arg_mappings.at(f.index) != UINT_MAX, stmt);
                         m_of << "%";
                         if( arg_mappings.at(f.index) == UINT8_MAX-1 ) {
@@ -5644,7 +5666,7 @@ namespace {
                         }
                         m_of << arg_mappings.at(f.index);
                     }
-                    m_of << FmtGccAsm(l.trailing, escape_percent);
+                    m_of << FmtGccAsm(xlat_dollars(l.trailing), escape_percent);
                     m_of << ";\\n ";
                 }
                 if( (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.options.att_syntax )

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -37,9 +37,11 @@ namespace {
     {
         const ::std::string& s;
         bool escape_percent;
-        FmtGccAsm(const ::std::string& s, bool escape_percent)
+        bool is_intel;
+        FmtGccAsm(const ::std::string& s, bool escape_percent, bool is_intel)
             : s(s)
             , escape_percent(escape_percent)
+            , is_intel(is_intel)
         {
         }
     };
@@ -151,7 +153,12 @@ namespace {
 ::std::ostream& operator<<(::std::ostream& os, const FmtGccAsm& x)
 {
     bool in_comment = false;
+    bool skip_next = false;
     for(const char& ch : x.s) {
+        if( skip_next ) {
+            skip_next = false;
+            continue;
+        }
         if( ch == '/' && (&ch)[1] == '/' ) {
             if( !in_comment ) {
                 os << "\" ";
@@ -177,6 +184,19 @@ namespace {
         case '{':   os << "%{";   break;
         case '}':   os << "%}";   break;
         case '|':   os << "%|";   break;
+        case '$':
+            // Rust `asm!` templates are LLVM asm templates, where `$N` is an operand reference and `$$` is a literal `$`.
+            // GCC uses `%N` for operands, so un-escape - except in intel-syntax blocks, where gas rejects the AT&T immediate prefix.
+            if( (&ch)[1] == '$' ) {
+                if( !x.is_intel ) {
+                    os << '$';
+                }
+                skip_next = true;
+            }
+            else {
+                os << ch;
+            }
+            break;
         default:    os << ch; break;
         }
     }
@@ -1624,21 +1644,22 @@ namespace {
 
         void emit_global_asm(const ::HIR::GlobalAssembly& se) override
         {
+            bool is_intel = (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.m_options.att_syntax;
             m_of << "__asm__ (\"";
-            if( (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.m_options.att_syntax )
+            if( is_intel )
                 m_of << ".intel_syntax noprefix; ";
             for(const auto& l : se.m_lines)
             {
                 for(const auto& f : l.frags)
                 {
-                    m_of << FmtGccAsm(f.before, false);
+                    m_of << FmtGccAsm(f.before, false, is_intel);
                     ASSERT_BUG(Span(), f.index < se.m_symbols.size(), "Invalid argument reference in global assembly");
                     TODO(Span(), "Handle interpolation in global_asm! - " << se.m_symbols[f.index]);
                 }
-                m_of << FmtGccAsm(l.trailing, false);
+                m_of << FmtGccAsm(l.trailing, false, is_intel);
                 m_of << ";\\n ";
             }
-            if( (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.m_options.att_syntax )
+            if( is_intel )
                 m_of << ".att_syntax; ";
             m_of << "\");\n";
         }
@@ -5621,14 +5642,15 @@ namespace {
                 m_of << indent << "__asm__ ";
                 m_of << "__volatile__"; // Default everything to volatile
                 m_of << "(\"";
-                if( (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.options.att_syntax )
+                bool is_intel = (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.options.att_syntax;
+                if( is_intel )
                     m_of << ".intel_syntax noprefix; ";
                 bool escape_percent = true || !inputs.empty() || !outputs.empty();
                 for(const auto& l : se.lines)
                 {
                     for(const auto& f : l.frags)
                     {
-                        m_of << FmtGccAsm(f.before, escape_percent);
+                        m_of << FmtGccAsm(f.before, escape_percent, is_intel);
                         MIR_ASSERT(mir_res, arg_mappings.at(f.index) != UINT_MAX, stmt);
                         m_of << "%";
                         if( arg_mappings.at(f.index) == UINT8_MAX-1 ) {
@@ -5650,10 +5672,10 @@ namespace {
                         }
                         m_of << arg_mappings.at(f.index);
                     }
-                    m_of << FmtGccAsm(l.trailing, escape_percent);
+                    m_of << FmtGccAsm(l.trailing, escape_percent, is_intel);
                     m_of << ";\\n ";
                 }
-                if( (Target_GetCurSpec().m_arch.m_name == "x86" || Target_GetCurSpec().m_arch.m_name == "x86_64") && !se.options.att_syntax )
+                if( is_intel )
                     m_of << ".att_syntax; ";
                 m_of << "\" :";
                 for(size_t i = 0; i < outputs.size(); i ++)


### PR DESCRIPTION
Rust `asm!` templates are LLVM asm templates: `$N` is an operand reference and
`$$` is the escape for a literal `$`. mrustc lowers them through the GCC
inline-asm protocol, where operands are `%`-prefixed and `$` has no escape, so
the doubled `$` survives into the assembly text.

With the `.intel_syntax noprefix` wrapper mrustc emits for x86, GAS then
evaluates `"$$0x80"` as a non-8-bit expression and rejects the `int`
instruction. This breaks rustix-1.0.8 on i586 — its i686 syscall wrappers use
`"int $$0x80"`.

## Change

The un-escaping lives in `operator<<(::std::ostream&, const FmtGccAsm&)`, next
to the existing `%`/`{`/`}`/`|` handling, rather than in a separate
pre-processing pass over the template. `FmtGccAsm` gains an `is_intel` flag:

* AT&T blocks: `$$` -> `$` (the immediate prefix is wanted);
* Intel blocks: `$$` -> nothing (GAS has no use for the AT&T immediate prefix
  and rejects it).

The "is this an intel-syntax block" test was already computed twice per
assembly block; it is now a local reused for the prologue, the epilogue and
the formatter.

This also applies the un-escaping to `global_asm!`, which shares `FmtGccAsm`
and is subject to exactly the same LLVM escaping rule.

## Testing

`bin/mrustc --target i586-unknown-linux-gnu` on a small `no_core` program
containing `asm!("int $$0x80", in("eax") 1usize, in("ebx") code)`:

```c
/* default (intel) */
__asm__ __volatile__(".intel_syntax noprefix; int 0x80;\n .att_syntax; " : ...);
/* options(att_syntax) */
__asm__ __volatile__("int $0x80;\n " : ...);
```

`make -f minicargo.mk local_tests RUSTC_VERSION=1.90.0` — 30 passed, 0 failed.
