### PR TITLE
fix(scripts): use RuntimeError instead of bare string in demangle.py

### DIFF
--- a/scripts/demangle.py
+++ b/scripts/demangle.py
@@ -108,7 +108,7 @@ def demangle_int_pathtrait(c_iter, rv):
 def demangle_int_params(c_iter, rv):
     n = demangle_int_getcount(c_iter)
     if next(c_iter) != 'g':
-        raise "error"
+        raise RuntimeError("error")
     if n == 0:
         return
     rv.push("<")


### PR DESCRIPTION
scripts/demangle.py line 111 contains `raise "error"` which is Python 2 syntax and does not work in Python 3. Under Python 3, this raises a confusing `TypeError: exceptions must derive from BaseException` instead of the intended runtime error.

**Before:**
```python
if next(c_iter) != 'g':
    raise "error"
```

**After:**
```python
if next(c_iter) != 'g':
    raise RuntimeError("error")
```

This is a minimal, single-line fix that preserves the existing error semantics. The other `raise` statements in the file (e.g. `raise Truncated()`, `raise Exception(...)`) are already Python 3 compatible. — Sent via @AmSach bot