### PR TITLE
HIR Item size reduction

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -348,6 +348,10 @@ public:
         s(s.c_str()),
         e(s.c_str() + s.size())
     {}
+    FmtEscaped(const char* s, size_t l):
+        s(s),
+        e(s + l)
+    {}
     // See main.cpp
     friend ::std::ostream& operator<<(::std::ostream& os, const FmtEscaped& x);
 };

--- a/src/expand/macro_rules.cpp
+++ b/src/expand/macro_rules.cpp
@@ -107,7 +107,7 @@ class CMacroUseHandler:
                     continue;
                 }
                 ASSERT_BUG(sp, ec.m_hir->m_root_module.m_macro_items.count(name) == 1, "Macro `" << name << "` missing from crate " << ec.m_name);
-                const auto* e = &*ec.m_hir->m_root_module.m_macro_items.at(name);
+                const auto* e = &ec.m_hir->m_root_module.m_macro_items.at(name);
                 if( !e->publicity.is_global() )
                 {
                     DEBUG("Not public: " << name);
@@ -125,7 +125,7 @@ class CMacroUseHandler:
                     const ::HIR::Module& mod = crate.m_extern_crates.at(imp->path.crate_name()).m_hir->get_mod_by_path(sp, imp->path, /*ignore_last_node*/true, /*ignore_crate_name*/true);
 
                     ASSERT_BUG(sp, mod.m_macro_items.count(imp->path.components().back()), "Failed to find final component of " << imp->path);
-                    e = &*mod.m_macro_items.at(imp->path.components().back());
+                    e = &mod.m_macro_items.at(imp->path.components().back());
                     if( const auto& imp2 = e->ent.opt_Import() ) {
                         if( imp2->path.crate_name() == CRATE_BUILTINS ) {
                             DEBUG("Importing builtin (skip): " << name);
@@ -144,7 +144,7 @@ class CMacroUseHandler:
                 TU_MATCH_HDRA( (e->ent), { )
                 TU_ARMA(Import, imp) { throw "Unexpected"; }
                 TU_ARMA(MacroRules, mac_ptr) { mr = &*mac_ptr; }
-                TU_ARMA(ProcMacro, p) { mr = &p; }
+                TU_ARMA(ProcMacro, p) { mr = &*p; }
                 }
                 if(!exists(name, mr))
                 {
@@ -305,8 +305,8 @@ class CMacroReexportHandler:
             if( it == ext_crate.m_exported_macro_names.end() )
                 ERROR(sp, E0000, "Could not find macro " << name << "! in crate " << crate_name);
             // TODO: Do this differently.
-            ext_crate.m_root_module.m_macro_items.at(name)->ent.as_MacroRules()->m_exported = true;
-            //ext_crate.m_root_module.m_macro_items.at(name)->publicity = AST::Publicity::new_global();
+            ext_crate.m_root_module.m_macro_items.at(name).ent.as_MacroRules()->m_exported = true;
+            //ext_crate.m_root_module.m_macro_items.at(name).publicity = AST::Publicity::new_global();
             });
     }
 };

--- a/src/expand/proc_macro.cpp
+++ b/src/expand/proc_macro.cpp
@@ -422,9 +422,9 @@ ProcMacroInv ProcMacro_Invoke_int(const Span& sp, const ::AST::Crate& crate, con
     const ::HIR::ProcMacro* pmp = nullptr;
     for(const auto& mi : ext_crate.m_hir->m_root_module.m_macro_items)
     {
-        if( !mi.second->ent.is_ProcMacro() )
+        if( !mi.second.ent.is_ProcMacro() )
             continue ;
-        const auto& pm = mi.second->ent.as_ProcMacro();
+        const auto& pm = *mi.second.ent.as_ProcMacro();
         bool good = true;
         for(size_t i = 0; i < ::std::min( mac_path.size()-1, pm.path.components().size() ); i++)
         {

--- a/src/hir/deserialise.cpp
+++ b/src/hir/deserialise.cpp
@@ -727,21 +727,21 @@ namespace {
                 return ::HIR::TypeItem::make_Import({ mv$(spath), is_variant, static_cast<unsigned int>(m_in.read_count()) });
                 }
             case 1:
-                return ::HIR::TypeItem( deserialise_module() );
+                return ::HIR::TypeItem( box$(deserialise_module()) );
             case 2:
-                return ::HIR::TypeItem( deserialise_typealias() );
+                return ::HIR::TypeItem( box$(deserialise_typealias()) );
             case 3:
-                return ::HIR::TypeItem( deserialise_enum() );
+                return ::HIR::TypeItem( box$(deserialise_enum()) );
             case 4:
-                return ::HIR::TypeItem( deserialise_struct() );
+                return ::HIR::TypeItem( box$(deserialise_struct()) );
             case 5:
-                return ::HIR::TypeItem( deserialise_trait() );
+                return ::HIR::TypeItem( box$(deserialise_trait()) );
             case 6:
-                return ::HIR::TypeItem( deserialise_union() );
+                return ::HIR::TypeItem( box$(deserialise_union()) );
             case 7:
-                return ::HIR::TypeItem( deserialise_externtype() );
+                return ::HIR::TypeItem( box$(deserialise_externtype()) );
             case 8:
-                return ::HIR::TypeItem( deserialise_traitalias() );
+                return ::HIR::TypeItem( box$(deserialise_traitalias()) );
             default:
                 BUG(Span(), "Bad tag for HIR::TypeItem - " << tag);
             }
@@ -756,13 +756,13 @@ namespace {
                 return ::HIR::ValueItem::make_Import({ mv$(spath), is_variant, static_cast<unsigned int>(m_in.read_count()) });
                 }
             case 1:
-                return ::HIR::ValueItem( deserialise_constant() );
+                return ::HIR::ValueItem( box$(deserialise_constant()) );
             case 2:
-                return ::HIR::ValueItem( deserialise_static() );
+                return ::HIR::ValueItem( box$(deserialise_static()) );
             case 3:
                 return ::HIR::ValueItem::make_StructConstant({ deserialise_simplepath() });
             case 4:
-                return ::HIR::ValueItem( deserialise_function() );
+                return ::HIR::ValueItem( box$(deserialise_function()) );
             case 5:
                 return ::HIR::ValueItem::make_StructConstructor({ deserialise_simplepath() });
             default:
@@ -783,7 +783,7 @@ namespace {
             case HIR::MacroItem::TAG_MacroRules:
                 return deserialise_macrorulesptr();
             case HIR::MacroItem::TAG_ProcMacro:
-                return deserialise_procmacro();
+                return box$(deserialise_procmacro());
             }
 
             TODO(Span(), "Bad tag for MacroItem - " << tag);
@@ -1724,9 +1724,9 @@ namespace {
         ::HIR::Module   rv;
 
         // m_traits doesn't need to be serialised
-        rv.m_value_items = deserialise_istrumap< ::std::unique_ptr< ::HIR::VisEnt< ::HIR::ValueItem> > >();
-        rv.m_mod_items = deserialise_istrumap< ::std::unique_ptr< ::HIR::VisEnt< ::HIR::TypeItem> > >();
-        rv.m_macro_items = deserialise_istrumap< ::std::unique_ptr< ::HIR::VisEnt< ::HIR::MacroItem> > >();
+        rv.m_value_items = deserialise_istrumap< ::HIR::VisEnt< ::HIR::ValueItem> >();
+        rv.m_mod_items   = deserialise_istrumap< ::HIR::VisEnt< ::HIR::TypeItem > >();
+        rv.m_macro_items = deserialise_istrumap< ::HIR::VisEnt< ::HIR::MacroItem> >();
 
         return rv;
     }

--- a/src/hir/deserialise.cpp
+++ b/src/hir/deserialise.cpp
@@ -691,7 +691,7 @@ namespace {
                 m_in.read( bytes.data(), bytes.size() );
                 return ::MIR::Constant::make_Bytes( mv$(bytes) );
                 }
-            _(StaticString, m_in.read_string() )
+            _(StaticString, RcString(m_in.read_string()) )  // NOTE: Not using `read_istring` to avoid polluting the interning map
             _(Const,  { box$(deserialise_path()) } )
             _(Generic,  deserialise_genericref())
             _(Function, { box$(deserialise_path()) } )
@@ -1691,7 +1691,7 @@ namespace {
         #define _(x, ...)    case ::MIR::SwitchValues::TAG_##x: return ::MIR::SwitchValues::make_##x( __VA_ARGS__ );
         _(Unsigned, deserialise_vec_c<uint64_t>([&](){ return m_in.read_u64c(); }))
         _(Signed  , deserialise_vec_c< int64_t>([&](){ return m_in.read_i64c(); }))
-        _(String  , deserialise_vec<::std::string>())
+        _(String  , deserialise_vec_c<RcString>([&](){ return RcString(m_in.read_string()); }))
         _(ByteString, deserialise_vec<::std::vector<uint8_t>>())
         #undef _
         default:

--- a/src/hir/from_ast.cpp
+++ b/src/hir/from_ast.cpp
@@ -1244,10 +1244,10 @@ namespace {
             // NOTE: I'd love to have this be a `Constant`, but that would require duplicating the type and the params
             // meh. Lazy option is to just duplicate
             auto name = RcString::new_interned(FMT(path.get_name() << "#default_" << field.m_name));
-            out_mod.m_value_items.insert(std::make_pair(name, ::std::make_unique<HIR::VisEnt<HIR::ValueItem>>(HIR::VisEnt<HIR::ValueItem>{
+            out_mod.m_value_items.insert(std::make_pair(name, HIR::VisEnt<HIR::ValueItem>{
                 HIR::Publicity::new_global(),
-                HIR::ValueItem(HIR::Constant(params.clone(), type.clone(), LowerHIR_Expr(field.m_default)))
-            })));
+                HIR::ValueItem(::std::make_unique<HIR::Constant>(params.clone(), type.clone(), LowerHIR_Expr(field.m_default)))
+            }));
             field_default = std::make_unique<HIR::GenericPath>((*path.parent + name).get_simple_path(), params.make_nop_params(0) );
         }
         fields.push_back(HIR::StructField {
@@ -1942,13 +1942,13 @@ namespace {
 }
 
 void _add_mod_ns_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pub,  ::HIR::TypeItem ti) {
-    mod.m_mod_items.insert( ::std::make_pair( mv$(name), ::make_unique_ptr(::HIR::VisEnt< ::HIR::TypeItem> { is_pub, mv$(ti) }) ) );
+    mod.m_mod_items.insert( ::std::make_pair( mv$(name), ::HIR::VisEnt< ::HIR::TypeItem> { is_pub, mv$(ti) }) );
 }
 void _add_mod_val_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pub,  ::HIR::ValueItem ti) {
-    mod.m_value_items.insert( ::std::make_pair( mv$(name), ::make_unique_ptr(::HIR::VisEnt< ::HIR::ValueItem> { is_pub, mv$(ti) }) ) );
+    mod.m_value_items.insert( ::std::make_pair( mv$(name), ::HIR::VisEnt< ::HIR::ValueItem> { is_pub, mv$(ti) }) );
 }
 void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pub,  ::HIR::MacroItem ti) {
-    mod.m_macro_items.insert( ::std::make_pair( mv$(name), ::make_unique_ptr(::HIR::VisEnt< ::HIR::MacroItem> { is_pub, mv$(ti) }) ) );
+    mod.m_macro_items.insert( ::std::make_pair( mv$(name), ::HIR::VisEnt< ::HIR::MacroItem> { is_pub, mv$(ti) }) );
 }
 
 ::HIR::ValueItem LowerHIR_Static(::HIR::ItemPath p, const ::AST::AttributeList& attrs, const ::AST::Static& e, const Span& sp, const RcString& name)
@@ -1957,7 +1957,7 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
 
     if( e.s_class() == ::AST::Static::CONST )
         // Note: Empty names are allowed for `const _: ...`
-        return ::HIR::ValueItem::make_Constant(::HIR::Constant(
+        return ::HIR::ValueItem::make_Constant(::std::make_unique<::HIR::Constant>(
             ::HIR::GenericParams {},
             LowerHIR_Type(e.type()),
             LowerHIR_Expr(e.value())
@@ -1986,7 +1986,7 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
             linkage.name = name.c_str();
         }
 
-        return ::HIR::ValueItem::make_Static(::HIR::Static(
+        return ::HIR::ValueItem::make_Static(::std::make_unique<::HIR::Static>(
             mv$(linkage),
             (e.s_class() == ::AST::Static::MUT),
             LowerHIR_Type(e.type()),
@@ -2038,7 +2038,7 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
             void push_trait_alias_hir(const HIR::TraitAlias& ta) {
                 for(const auto& p : ta.m_traits) {
                     if( const auto* tap = g_crate_ptr->get_typeitem_by_path(Span(), p.m_path.m_path).opt_TraitAlias()) {
-                        push_trait_alias_hir(*tap);
+                        push_trait_alias_hir(**tap);
                     }
                     else {
                         push_trait(p.m_path.m_path);
@@ -2067,7 +2067,7 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
             auto& submod = *submod_ptr;
             auto name = RcString::new_interned(FMT("#" << i));
             auto item_path = ::HIR::ItemPath(path, name.c_str());
-            auto ti = ::HIR::TypeItem::make_Module( LowerHIR_Module(submod, item_path, mod.m_traits) );
+            auto ti = ::HIR::TypeItem::make_Module( ::std::make_unique<HIR::Module>(LowerHIR_Module(submod, item_path, mod.m_traits)) );
             _add_mod_ns_item( mod,  mv$(name), ::HIR::Publicity::new_priv(mod_path), mv$(ti) );
         }
     }
@@ -2118,7 +2118,7 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
             // Ignore - The index is used to add `Import`s
             }
         TU_ARMA(Module, e) {
-            _add_mod_ns_item( mod, item.name, get_vis(item.vis), LowerHIR_Module(e, mv$(item_path)) );
+            _add_mod_ns_item( mod, item.name, get_vis(item.vis), ::std::make_unique<HIR::Module>(LowerHIR_Module(e, mv$(item_path))) );
             }
         TU_ARMA(Crate, e) {
             // All 'extern crate' items should be normalised into a list in the crate root
@@ -2132,10 +2132,10 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
                 {
                     ERROR(item.span, E0000, "Generics on extern type");
                 }
-                _add_mod_ns_item(mod, item.name, get_vis(item.vis), ::HIR::ExternType {});
+                _add_mod_ns_item(mod, item.name, get_vis(item.vis), ::std::make_unique<::HIR::ExternType>());
                 break;
             }
-            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), ::HIR::TypeItem::make_TypeAlias( LowerHIR_TypeAlias(item_path, e) ) );
+            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), ::HIR::TypeItem::make_TypeAlias( ::std::make_unique<HIR::TypeAlias>(LowerHIR_TypeAlias(item_path, e)) ) );
             }
         TU_ARMA(Struct, e) {
             /// Add value reference
@@ -2147,26 +2147,28 @@ void _add_mod_mac_item(::HIR::Module& mod, RcString name, ::HIR::Publicity is_pu
             }
             else {
             }
-            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), LowerHIR_Struct(ip->span, item_path, e, item.attrs, mod) );
+            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), box$(LowerHIR_Struct(ip->span, item_path, e, item.attrs, mod)) );
             }
         TU_ARMA(Enum, e) {
-            auto enm = LowerHIR_Enum(item_path, e, item.attrs, [&](auto name, auto str){ _add_mod_ns_item(mod, name, get_vis(item.vis), mv$(str)); }, mod);
-            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), mv$(enm) );
+            auto enm = LowerHIR_Enum(item_path, e, item.attrs, [&](RcString name, HIR::Struct str){
+                _add_mod_ns_item(mod, name, get_vis(item.vis), box$(str));
+            }, mod);
+            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), box$(enm) );
             }
         TU_ARMA(Union, e) {
-            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), LowerHIR_Union(item_path, e, item.attrs) );
+            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), box$(LowerHIR_Union(item_path, e, item.attrs)) );
             }
         TU_ARMA(Trait, e) {
-            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), LowerHIR_Trait(item_path.get_simple_path(), e) );
+            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), box$(LowerHIR_Trait(item_path.get_simple_path(), e)) );
             }
         TU_ARMA(TraitAlias, e) {
-            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), LowerHIR_TraitAlias(sp, item_path, e) );
+            _add_mod_ns_item( mod,  item.name, get_vis(item.vis), box$(LowerHIR_TraitAlias(sp, item_path, e)) );
             }
         TU_ARMA(Function, e) {
-            _add_mod_val_item(mod, item.name, get_vis(item.vis),  LowerHIR_Function(item_path, item.attrs, e, ::HIR::TypeRef{}));
+            _add_mod_val_item( mod, item.name, get_vis(item.vis), box$(LowerHIR_Function(item_path, item.attrs, e, ::HIR::TypeRef{})) );
             }
         TU_ARMA(Static, e) {
-            _add_mod_val_item(mod, item.name, get_vis(item.vis),  LowerHIR_Static(item_path, item.attrs, e, sp, item.name));
+            _add_mod_val_item( mod, item.name, get_vis(item.vis), LowerHIR_Static(item_path, item.attrs, e, sp, item.name) );
             }
         }
     }
@@ -2598,7 +2600,7 @@ public:
             };
             // Register under an invalid SimplePath
             ::HIR::ProcMacro::Ty    ty = H::cvt_macro_ty(ent.ty);
-            macros.insert( std::make_pair(ent.name, ::HIR::ProcMacro { ty, ent.name, ::HIR::SimplePath(RcString(""), { ent.name }), ent.attributes }) );
+            macros.insert( std::make_pair(ent.name, make_unique_ptr(::HIR::ProcMacro { ty, ent.name, ::HIR::SimplePath(RcString(""), { ent.name }), ent.attributes })) );
             rv.m_exported_macro_names.push_back(ent.name);
             DEBUG("Export proc_macro " << ent.name);
         }
@@ -2662,7 +2664,7 @@ public:
         if(e.second.is_MacroRules() ) {
             ASSERT_BUG(Span(), !e.second.as_MacroRules()->m_rules.empty(), "Empty macro? - " << e.first);
         }
-        rv.m_root_module.m_macro_items.insert( ::std::make_pair(e.first, box$(HIR::VisEnt<HIR::MacroItem> { HIR::Publicity::new_global(), mv$(e.second) })) );
+        rv.m_root_module.m_macro_items.insert( ::std::make_pair(e.first, HIR::VisEnt<HIR::MacroItem> { HIR::Publicity::new_global(), mv$(e.second) }) );
     }
 
     LowerHIR_Module_Impls(crate.m_root_module,  rv);
@@ -2687,16 +2689,16 @@ public:
                     if( it2 == mod->m_mod_items.end() )
                         return ::HIR::SimplePath();
                     const auto& e = it2->second;
-                    if(const auto* ip = e->ent.opt_Import())
+                    if(const auto* ip = e.ent.opt_Import())
                     {
                         // TODO: Handle module aliases?
                         (void)ip;
                         return ::HIR::SimplePath();
                     }
-                    else if(const auto* ep = e->ent.opt_Module() )
+                    else if(const auto* ep = e.ent.opt_Module() )
                     {
                         cur_path_components.push_back(*it);
-                        mod = ep;
+                        mod = &**ep;
                     }
                     else
                     {
@@ -2717,7 +2719,7 @@ public:
                         return ::HIR::SimplePath();
 
                     // Found: Either return the current path, or return this alias.
-                    if(const auto* ip = it2->second->ent.opt_Import())
+                    if(const auto* ip = it2->second.ent.opt_Import())
                     {
                         if(ip->is_variant)
                             return ::HIR::SimplePath();
@@ -2899,12 +2901,12 @@ public:
             {
                 TRACE_FUNCTION_F(path);
                 for(auto& mi : mod.m_mod_items) {
-                    if(auto* submod_p = mi.second->ent.opt_Module()) {
-                        fix_macros_in_mod(path + mi.first, *submod_p);
+                    if(auto* submod_p = mi.second.ent.opt_Module()) {
+                        fix_macros_in_mod(path + mi.first, **submod_p);
                     }
                 }
                 for(auto& mi : mod.m_macro_items) {
-                    if(auto* mrpp = mi.second->ent.opt_MacroRules()) {
+                    if(auto* mrpp = mi.second.ent.opt_MacroRules()) {
                         auto& mr = **mrpp;
                         if( mr.m_source_crate.size() == 0 ) {
                             mr.m_source_crate = g_crate_name;
@@ -2914,7 +2916,7 @@ public:
                             fix_macro_contents(rule.m_contents);
                         }
                     }
-                    if( const auto* i = mi.second->ent.opt_Import() ) {
+                    if( const auto* i = mi.second.ent.opt_Import() ) {
                         DEBUG(path << ": Import " << mi.first << " = " << i->path);
                         if( i->path.crate_name() == CRATE_BUILTINS ) {
                         }

--- a/src/hir/hir.cpp
+++ b/src/hir/hir.cpp
@@ -336,8 +336,8 @@ namespace {
             if( it == mod->m_mod_items.end() ) {
                 BUG(sp, "Couldn't find component " << i << " of " << path);
             }
-            if(const auto* e = it->second->ent.opt_Module()) {
-                mod = e;
+            if(const auto* e = it->second.ent.opt_Module()) {
+                mod = &**e;
             }
             else {
                 BUG(sp, "Node " << i << " of path " << path << " wasn't a module");
@@ -356,7 +356,7 @@ const ::HIR::MacroItem& ::HIR::Crate::get_macroitem_by_path(const Span& sp, cons
         BUG(sp, "Could not find macro name in " << path);
     }
 
-    return it->second->ent;
+    return it->second.ent;
 }
 
 const ::HIR::TypeItem& ::HIR::Crate::get_typeitem_by_path(const Span& sp, const ::HIR::SimplePath& path, bool ignore_crate_name, bool ignore_last_node) const
@@ -368,7 +368,7 @@ const ::HIR::TypeItem& ::HIR::Crate::get_typeitem_by_path(const Span& sp, const 
         BUG(sp, "Could not find type " << path);
     }
 
-    return it->second->ent;
+    return it->second.ent;
 }
 
 const ::HIR::Module& ::HIR::Crate::get_mod_by_path(const Span& sp, const ::HIR::SimplePath& path, bool ignore_last_node/*=false*/, bool ignore_crate_name/*=false*/) const
@@ -395,7 +395,7 @@ const ::HIR::Module& ::HIR::Crate::get_mod_by_path(const Span& sp, const ::HIR::
         const auto& ti = this->get_typeitem_by_path(sp, path, ignore_crate_name, ignore_last_node);
         if(auto* e = ti.opt_Module())
         {
-            return *e;
+            return **e;
         }
         else {
             if( ignore_last_node )
@@ -409,7 +409,7 @@ const ::HIR::Trait& ::HIR::Crate::get_trait_by_path(const Span& sp, const ::HIR:
 {
     const auto& ti = this->get_typeitem_by_path(sp, path);
     TU_IFLET(::HIR::TypeItem, ti, Trait, e,
-        return e;
+        return *e;
     )
     else {
         BUG(sp, "Trait path " << path << " didn't point to a trait (" << ti.tag_str() << ")");
@@ -419,7 +419,7 @@ const ::HIR::Struct& ::HIR::Crate::get_struct_by_path(const Span& sp, const ::HI
 {
     const auto& ti = this->get_typeitem_by_path(sp, path);
     TU_IFLET(::HIR::TypeItem, ti, Struct, e,
-        return e;
+        return *e;
     )
     else {
         BUG(sp, "Struct path " << path << " didn't point to a struct (" << ti.tag_str() << ")");
@@ -429,7 +429,7 @@ const ::HIR::Union& ::HIR::Crate::get_union_by_path(const Span& sp, const ::HIR:
 {
     const auto& ti = this->get_typeitem_by_path(sp, path);
     TU_IFLET(::HIR::TypeItem, ti, Union, e,
-        return e;
+        return *e;
     )
     else {
         BUG(sp, "Path " << path << " didn't point to a union (" << ti.tag_str() << ")");
@@ -439,7 +439,7 @@ const ::HIR::Enum& ::HIR::Crate::get_enum_by_path(const Span& sp, const ::HIR::S
 {
     const auto& ti = this->get_typeitem_by_path(sp, path, ignore_crate_name, ignore_last_node);
     TU_IFLET(::HIR::TypeItem, ti, Enum, e,
-        return e;
+        return *e;
     )
     else {
         BUG(sp, "Enum path " << path << " didn't point to an enum (" << ti.tag_str() << ")");
@@ -447,14 +447,14 @@ const ::HIR::Enum& ::HIR::Crate::get_enum_by_path(const Span& sp, const ::HIR::S
 }
 
 namespace {
-    ::HIR::ValueItem    g_val_item_intrnsic_offsetof {
-        ::HIR::Function {
+    ::HIR::ValueItem    g_val_item_intrinsic_offsetof {
+        box$(::HIR::Function {
             ::HIR::Function::Receiver::Free,
             ::HIR::GenericParams {},
             {},
             HIR::TypeRef(HIR::CoreType::Usize),
             {}
-        }
+        })
     };
 }
 
@@ -463,19 +463,19 @@ const ::HIR::ValueItem& ::HIR::Crate::get_valitem_by_path(const Span& sp, const 
     if( path.crate_name() == "#intrinsics" ) {
         ASSERT_BUG(sp, path.components().size() == 1, "");
         if( path.components().back() == "offset_of" ) {
-            if( ! g_val_item_intrnsic_offsetof.as_Function().m_variadic ) {
-                auto& v =  g_val_item_intrnsic_offsetof.as_Function();
+            if( ! g_val_item_intrinsic_offsetof.as_Function()->m_variadic ) {
+                auto& v = *g_val_item_intrinsic_offsetof.as_Function();
                 v.m_variadic = true;
                 v.m_params.m_types.push_back(HIR::TypeParamDef { RcString::new_interned("T"), {}, true });
             }
-            return g_val_item_intrnsic_offsetof;
+            return g_val_item_intrinsic_offsetof;
         }
         TODO(sp, "Get intrinsic " << path.components().back());
     }
     if( path.crate_name() == this->m_crate_name && path.components().size() == 1 ) {
         auto i = std::find_if(m_new_values.begin(), m_new_values.end(), [&](const auto& v){ return v.first == path.components().back(); });
         if( i != m_new_values.end() ) {
-            return i->second->ent;
+            return i->second.ent;
         }
     }
     const auto& mod = get_containing_module(*this, sp, path, ignore_crate_name, /*ignore_last_node=*/false);
@@ -485,13 +485,13 @@ const ::HIR::ValueItem& ::HIR::Crate::get_valitem_by_path(const Span& sp, const 
         BUG(sp, "Could not find value name " << path);
     }
 
-    return it->second->ent;
+    return it->second.ent;
 }
 const ::HIR::Function& ::HIR::Crate::get_function_by_path(const Span& sp, const ::HIR::SimplePath& path) const
 {
     const auto& ti = this->get_valitem_by_path(sp, path);
     TU_IFLET(::HIR::ValueItem, ti, Function, e,
-        return e;
+        return *e;
     )
     else {
         BUG(sp, "Function path " << path << " didn't point to an function (" << ti.tag_str() << ")");
@@ -505,8 +505,8 @@ const ::HIR::Static& ::HIR::Crate::get_static_by_path(const Span& sp, const ::HI
     auto it = m.m_value_items.find(path.components().back());
     if(it != m.m_value_items.end())
     {
-        ASSERT_BUG(sp, it->second->ent.is_Static(), "`static` path " << path << " didn't point to a static - " << it->second->ent.tag_str());
-        return it->second->ent.as_Static();
+        ASSERT_BUG(sp, it->second.ent.is_Static(), "`static` path " << path << " didn't point to a static - " << it->second.ent.tag_str());
+        return *it->second.ent.as_Static();
     }
     for(const auto& e : m.m_inline_statics)
     {
@@ -518,7 +518,7 @@ const ::HIR::Static& ::HIR::Crate::get_static_by_path(const Span& sp, const ::HI
     if( path.crate_name() == this->m_crate_name && path.components().size() == 1 ) {
         auto i = std::find_if(m_new_values.begin(), m_new_values.end(), [&](const auto& v){ return v.first == path.components().back(); });
         if( i != m_new_values.end() ) {
-            return i->second->ent.as_Static();
+            return *i->second.ent.as_Static();
         }
     }
     BUG(sp, "`static` path " << path << " can't be found");

--- a/src/hir/hir.hpp
+++ b/src/hir/hir.hpp
@@ -531,11 +531,11 @@ public:
     ::std::vector< ::HIR::SimplePath>   m_traits;
 
     // Contains all values and functions (including type constructors)
-    ::std::unordered_map< RcString, ::std::unique_ptr<VisEnt<ValueItem>> > m_value_items;
+    ::std::unordered_map< RcString, VisEnt<ValueItem> > m_value_items;
     // Contains types, traits, and modules
-    ::std::unordered_map< RcString, ::std::unique_ptr<VisEnt<TypeItem>> > m_mod_items;
+    ::std::unordered_map< RcString, VisEnt<TypeItem> > m_mod_items;
     // Macros!
-    ::std::unordered_map< RcString, ::std::unique_ptr<VisEnt<MacroItem>> > m_macro_items;
+    ::std::unordered_map< RcString, VisEnt<MacroItem> > m_macro_items;
 
     ::std::vector< ::std::pair<RcString, std::unique_ptr<Static>> >  m_inline_statics;
 
@@ -550,27 +550,27 @@ public:
 
 TAGGED_UNION(TypeItem, Import,
     (Import, struct { ::HIR::SimplePath path; bool is_variant; unsigned int idx; }),
-    (Module, Module),
-    (TypeAlias, TypeAlias), // NOTE: These don't introduce new values
-    (TraitAlias, TraitAlias),
-    (ExternType, ExternType),
-    (Enum,      Enum),
-    (Struct,    Struct),
-    (Union,     Union),
-    (Trait,     Trait)
+    (Module    , ::std::unique_ptr<Module>),
+    (TypeAlias , ::std::unique_ptr<TypeAlias>), // NOTE: These don't introduce new values
+    (TraitAlias, ::std::unique_ptr<TraitAlias>),
+    (ExternType, ::std::unique_ptr<ExternType>),
+    (Enum,      ::std::unique_ptr<Enum>),
+    (Struct,    ::std::unique_ptr<Struct>),
+    (Union,     ::std::unique_ptr<Union>),
+    (Trait,     ::std::unique_ptr<Trait>)
     );
 TAGGED_UNION(ValueItem, Import,
     (Import,    struct { ::HIR::SimplePath path; bool is_variant; unsigned int idx; }),
-    (Constant,  Constant),
-    (Static,    Static),
+    (Constant,  ::std::unique_ptr<Constant>),
+    (Static,    ::std::unique_ptr<Static>),
     (StructConstant,    struct { ::HIR::SimplePath ty; }),
-    (Function,  Function),
+    (Function,  ::std::unique_ptr<Function>),
     (StructConstructor, struct { ::HIR::SimplePath ty; })
     );
 TAGGED_UNION(MacroItem, Import,
     (Import, struct { ::HIR::SimplePath path; }),
     (MacroRules, MacroRulesPtr),
-    (ProcMacro, ProcMacro)
+    (ProcMacro, ::std::unique_ptr<ProcMacro>)
     );
 
 // --------------------------------------------------------------------
@@ -677,8 +677,8 @@ public:
     Module  m_root_module;
 
     // Placeholder for types created during constant evaluation
-    mutable std::vector<std::pair<RcString, std::unique_ptr<VisEnt<TypeItem>> >>  m_new_types;
-    mutable std::vector<std::pair<RcString, std::unique_ptr<VisEnt<ValueItem>> >> m_new_values;
+    mutable std::vector<std::pair<RcString, VisEnt<TypeItem> >>  m_new_types;
+    mutable std::vector<std::pair<RcString, VisEnt<ValueItem> >> m_new_values;
 
     template<typename T>
     struct ImplGroup
@@ -773,9 +773,9 @@ public:
 
     const ::HIR::Constant& get_constant_by_path(const Span& sp, const ::HIR::SimplePath& path) const {
         const auto& ti = this->get_valitem_by_path(sp, path);
-        TU_IFLET(::HIR::ValueItem, ti, Constant, e,
-            return e;
-        )
+        if( const auto* ep = ti.opt_Constant() ) {
+            return **ep;
+        }
         else {
             BUG(sp, "`const` path " << path << " didn't point to an enum");
         }

--- a/src/hir/serialise.cpp
+++ b/src/hir/serialise.cpp
@@ -1114,35 +1114,35 @@
                 ),
             (Module,
                 m_out.write_tag(1);
-                serialise_module(e);
+                serialise_module(*e);
                 ),
             (TypeAlias,
                 m_out.write_tag(2);
-                serialise(e);
+                serialise(*e);
                 ),
             (Enum,
                 m_out.write_tag(3);
-                serialise(e);
+                serialise(*e);
                 ),
             (Struct,
                 m_out.write_tag(4);
-                serialise(e);
+                serialise(*e);
                 ),
             (Trait,
                 m_out.write_tag(5);
-                serialise(e);
+                serialise(*e);
                 ),
             (Union,
                 m_out.write_tag(6);
-                serialise(e);
+                serialise(*e);
                 ),
             (ExternType,
                 m_out.write_tag(7);
-                serialise(e);
+                serialise(*e);
                 ),
             (TraitAlias,
                 m_out.write_tag(8);
-                serialise(e);
+                serialise(*e);
                 )
             )
         }

--- a/src/hir/serialise.cpp
+++ b/src/hir/serialise.cpp
@@ -114,6 +114,16 @@
                 serialise(i);
         }
         template<typename T>
+        void serialise_vec_c(const ::std::vector<T>& vec, ::std::function<void(const T&)> cb)
+        {
+            TRACE_FUNCTION_F("<" << typeid(T).name() << "> size=" << vec.size());
+            auto _ = m_out.open_object(typeid(::std::vector<T>).name());
+            m_out.write_count(vec.size());
+            for(const auto& i : vec) {
+                cb(i);
+            }
+        }
+        template<typename T>
         void serialise(const ::std::vector<T>& vec)
         {
             serialise_vec(vec);
@@ -942,7 +952,8 @@
                 serialise_vec(e);
                 }
             TU_ARMA(String, e) {
-                serialise_vec(e);
+                //serialise_vec(e);
+                serialise_vec_c<RcString>(e, [&](const RcString& s){ m_out.write_string(s.size(), s.c_str()); });
                 }
             TU_ARMA(ByteString, e) {
                 serialise_vec(e);
@@ -1085,7 +1096,7 @@
                 m_out.write( e.data(), e.size() );
                 ),
             (StaticString,
-                m_out.write_string(e);
+                m_out.write_string(e.size(), e.c_str());
                 ),
             (Const,
                 ASSERT_BUG(Span(), monomorphise_path_needed(*e.p), "Unexpected Constant: " << *e.p);

--- a/src/hir/visitor.cpp
+++ b/src/hir/visitor.cpp
@@ -55,64 +55,64 @@ void ::HIR::Visitor::visit_module(::HIR::ItemPath p, ::HIR::Module& mod)
     for( auto& named : mod.m_mod_items )
     {
         const auto& name = named.first;
-        auto& item = named.second->ent;
+        auto& item = named.second.ent;
         TU_MATCH_HDRA( (item), {)
         TU_ARMA(Import, e) {}
         TU_ARMA(Module, e) {
             TRACE_FUNCTION_F("mod " << name);
-            this->visit_module(p + name, e);
+            this->visit_module(p + name, *e);
             }
         TU_ARMA(TypeAlias, e) {
             TRACE_FUNCTION_F("type " << name);
-            this->visit_type_alias(p + name, e);
+            this->visit_type_alias(p + name, *e);
             }
         TU_ARMA(TraitAlias, e) {
             TRACE_FUNCTION_F("trait (alias) " << name);
-            this->visit_trait_alias(p + name, e);
+            this->visit_trait_alias(p + name, *e);
             }
         TU_ARMA(ExternType, e) {
             TRACE_FUNCTION_F("extern type " << name);
             }
         TU_ARMA(Enum, e) {
             TRACE_FUNCTION_F("enum " << name);
-            this->visit_enum(p + name, e);
+            this->visit_enum(p + name, *e);
             }
         TU_ARMA(Struct, e) {
             TRACE_FUNCTION_F("struct " << name);
-            this->visit_struct(p + name, e);
+            this->visit_struct(p + name, *e);
             }
         TU_ARMA(Union, e) {
             TRACE_FUNCTION_F("union " << name);
-            this->visit_union(p + name, e);
+            this->visit_union(p + name, *e);
             }
         TU_ARMA(Trait, e) {
             TRACE_FUNCTION_F("trait " << name);
-            this->visit_trait(p + name, e);
+            this->visit_trait(p + name, *e);
             }
         }
     }
     for( auto& named : mod.m_value_items )
     {
         const auto& name = named.first;
-        auto& item = named.second->ent;
+        auto& item = named.second.ent;
         TU_MATCH_HDRA( (item), {)
         TU_ARMA(Import, e) {
             // SimplePath - no visitor
             }
         TU_ARMA(Constant, e) {
             DEBUG("const " << name);
-            this->visit_constant(p + name, e);
+            this->visit_constant(p + name, *e);
             }
         TU_ARMA(Static, e) {
             DEBUG("static " << name);
-            this->visit_static(p + name, e);
+            this->visit_static(p + name, *e);
             }
         TU_ARMA(StructConstant, e) {
             // Just a path
             }
         TU_ARMA(Function, e) {
             DEBUG("fn " << name);
-            this->visit_function(p + name, e);
+            this->visit_function(p + name, *e);
             }
         TU_ARMA(StructConstructor, e) {
             // Just a path

--- a/src/hir_conv/bind.cpp
+++ b/src/hir_conv/bind.cpp
@@ -229,27 +229,27 @@ namespace {
                     else
                     {
                         const auto& ti = m_crate.get_typeitem_by_path(sp, path, /*ignore_crate_name=*/false, /*ignore_last_node=*/true);
-                        if( const auto& enm = ti.opt_Enum() )
+                        if( const auto* enm = ti.opt_Enum() )
                         {
                             if( !is_single_value ) {
                                 ERROR(sp, E0000, "Enum variant in range pattern - " << pat);
                             }
 
                             // Enum variant
-                            auto idx = enm->find_variant(pc);
+                            auto idx = (*enm)->find_variant(pc);
                             if( idx == SIZE_MAX ) {
                                 BUG(sp, "'" << pc << "' isn't a variant in path " << path);
                             }
                             HIR::GenericPath path = std::move(*pe);
-                            fix_type_params(sp, enm->m_params,  path.m_params);
+                            fix_type_params(sp, (*enm)->m_params,  path.m_params);
                             pat.m_data = ::HIR::Pattern::Data::make_PathValue({
                                 mv$(path),
-                                ::HIR::Pattern::PathBinding::make_Enum({ enm, static_cast<unsigned>(idx) })
+                                ::HIR::Pattern::PathBinding::make_Enum({ &**enm, static_cast<unsigned>(idx) })
                                 });
                         }
-                        else if( (mod = ti.opt_Module()) )
+                        else if( const auto* mod_p = ti.opt_Module() )
                         {
-                            mod = &ti.as_Module();
+                            mod = &**mod_p;
                         }
                         else
                         {
@@ -264,15 +264,15 @@ namespace {
                             BUG(sp, "Couldn't find final component of " << path);
                         }
                         // Unit-like struct match or a constant
-                        TU_MATCH_HDRA( (it->second->ent), { )
+                        TU_MATCH_HDRA( (it->second.ent), { )
                         default:
-                            ERROR(sp, E0000, "Value pattern " << pat << " pointing to unexpected item type - " << it->second->ent.tag_str());
+                            ERROR(sp, E0000, "Value pattern " << pat << " pointing to unexpected item type - " << it->second.ent.tag_str());
                         TU_ARMA(Constant, e2) {
                             // Store reference to this item for later use
-                            ve->binding = &e2;
+                            ve->binding = &*e2;
                             }
                         TU_ARMA(StructConstant, e2) {
-                            const auto& str = mod->m_mod_items.find(pc)->second->ent.as_Struct();
+                            const auto& str = *mod->m_mod_items.find(pc)->second.ent.as_Struct();
                             // Convert into a dedicated pattern type
                             if( !is_single_value ) {
                                 ERROR(sp, E0000, "Struct in range pattern - " << pat);
@@ -396,22 +396,22 @@ namespace {
                         // Assume it'll be filled out, with the correct binding
                         ),
                     (ExternType,
-                        e->binding = ::HIR::TypePathBinding::make_ExternType(&e3);
+                        e->binding = ::HIR::TypePathBinding::make_ExternType(&*e3);
                         DEBUG("- " << ty);
                         ),
                     (Struct,
-                        fix_param_count(sp, pe, e3.m_params,  pe.m_params, /*fill_infer=*/m_in_expr!=0);
-                        e->binding = ::HIR::TypePathBinding::make_Struct(&e3);
+                        fix_param_count(sp, pe, e3->m_params,  pe.m_params, /*fill_infer=*/m_in_expr!=0);
+                        e->binding = ::HIR::TypePathBinding::make_Struct(&*e3);
                         DEBUG("- " << ty);
                         ),
                     (Union,
-                        fix_param_count(sp, pe, e3.m_params,  pe.m_params, /*fill_infer=*/m_in_expr!=0);
-                        e->binding = ::HIR::TypePathBinding::make_Union(&e3);
+                        fix_param_count(sp, pe, e3->m_params,  pe.m_params, /*fill_infer=*/m_in_expr!=0);
+                        e->binding = ::HIR::TypePathBinding::make_Union(&*e3);
                         DEBUG("- " << ty);
                         ),
                     (Enum,
-                        fix_param_count(sp, pe, e3.m_params,  pe.m_params, /*fill_infer=*/m_in_expr!=0);
-                        e->binding = ::HIR::TypePathBinding::make_Enum(&e3);
+                        fix_param_count(sp, pe, e3->m_params,  pe.m_params, /*fill_infer=*/m_in_expr!=0);
+                        e->binding = ::HIR::TypePathBinding::make_Enum(&*e3);
                         DEBUG("- " << ty);
                         ),
                     (Trait,

--- a/src/hir_conv/constant_evaluation.cpp
+++ b/src/hir_conv/constant_evaluation.cpp
@@ -855,12 +855,15 @@ namespace {
         return ofs;
     }
 
+    const ::HIR::Module* get_opt_mod(const ::std::unique_ptr<::HIR::Module>* opt_mp) {
+        return opt_mp ? opt_mp->get() : nullptr;
+    }
     EntPtr get_ent_fullpath(const Span& sp, const ::StaticTraitResolve& resolve, const ::HIR::Path& path, EntNS ns, MonomorphState& out_ms, const ::HIR::GenericParams** out_impl_params_def=nullptr)
     {
         if(const auto* gp = path.m_data.opt_Generic()) {
             const auto& name = gp->m_path.components().back();
             const auto* mod = ( gp->m_path.components().size() > 1 )
-                ? resolve.m_crate.get_typeitem_by_path(sp, gp->m_path, false, /*ignore_last*/true) . opt_Module()
+                ? get_opt_mod(resolve.m_crate.get_typeitem_by_path(sp, gp->m_path, false, /*ignore_last*/true).opt_Module())
                 : &resolve.m_crate.get_mod_by_path(sp, gp->m_path, true)
                 ;
             if( mod ) {
@@ -1122,7 +1125,7 @@ namespace MIR { namespace eval {
                     DEBUG(p << " = " << item.m_value_res);
                 }
                 if(out_ty) {
-                    // Does this need monomorph? No, becuase the value is known and thus not generic?
+                    // Does this need monomorph? No, because the value is known and thus not generic?
                     *out_ty = s.m_type.clone();
                 }
                 return StaticRefPtr::allocate(std::move(p), &s.m_value_res);
@@ -3377,8 +3380,8 @@ namespace {
                     TU_MATCH_HDRA( (vi), { )
                     TU_ARMA(Import, e)  BUG(sp, "Module Import");
                     TU_ARMA(Static, e)  BUG(sp, "Getting params definition for Static - " << p);
-                    TU_ARMA(Constant, e)    return e.m_params;
-                    TU_ARMA(Function, e)    return e.m_params;
+                    TU_ARMA(Constant, e)    return e->m_params;
+                    TU_ARMA(Function, e)    return e->m_params;
                     TU_ARMA(StructConstant, e)   return m_crate.get_struct_by_path(sp, e.ty).m_params;
                     TU_ARMA(StructConstructor, e)   return m_crate.get_struct_by_path(sp, e.ty).m_params;
                     }
@@ -3391,10 +3394,10 @@ namespace {
                     TU_ARMA(Module, e)  BUG(sp, "mod - " << p);
                     TU_ARMA(TypeAlias, e)  BUG(sp, "type - " << p);
                     TU_ARMA(TraitAlias, e)  BUG(sp, "trait= - " << p);
-                    TU_ARMA(Struct, e)  return e.m_params;
-                    TU_ARMA(Enum , e)   return e.m_params;
-                    TU_ARMA(Union, e)   return e.m_params;
-                    TU_ARMA(Trait, e)   return e.m_params;
+                    TU_ARMA(Struct, e)  return e->m_params;
+                    TU_ARMA(Enum , e)   return e->m_params;
+                    TU_ARMA(Union, e)   return e->m_params;
+                    TU_ARMA(Trait, e)   return e->m_params;
                     TU_ARMA(ExternType, e)   BUG(sp, "extern type - " << p);
                     }
                     break; }
@@ -3775,10 +3778,7 @@ namespace {
             {
                 for(auto& v : mod.m_inline_statics)
                 {
-                    // ::std::unique_ptr<VisEnt<ValueItem>>
-                    ::std::unique_ptr<::HIR::VisEnt<::HIR::ValueItem>>  iv;
-                    iv.reset( new ::HIR::VisEnt<::HIR::ValueItem> { ::HIR::Publicity::new_none(), ::HIR::ValueItem::make_Static(mv$(*v.second)) } );
-                    mod.m_value_items.insert(::std::make_pair( v.first, mv$(iv) ));
+                    mod.m_value_items.insert(::std::make_pair( v.first, ::HIR::VisEnt<::HIR::ValueItem> { ::HIR::Publicity::new_none(), ::HIR::ValueItem::make_Static(box$(*v.second)) } ));
                 }
                 mod.m_inline_statics.clear();
             }

--- a/src/hir_conv/constant_evaluation.cpp
+++ b/src/hir_conv/constant_evaluation.cpp
@@ -1409,7 +1409,7 @@ namespace MIR { namespace eval {
                 dst.write_ptr(state, EncodedLiteral::PTR_BASE, ConstantPtr::allocate(e2.data(), e2.size()));
             }
             TU_ARM(c, StaticString, e2) {
-                dst.write_ptr(state, EncodedLiteral::PTR_BASE, ConstantPtr::allocate(e2.data(), e2.size()));
+                dst.write_ptr(state, EncodedLiteral::PTR_BASE, ConstantPtr::allocate(e2.c_str(), e2.size()));
                 dst.slice(Target_GetPointerBits()/8).write_uint(state, Target_GetPointerBits(), e2.size());
             }
             TU_ARM(c, Const, e2) {

--- a/src/hir_conv/expand_type.cpp
+++ b/src/hir_conv/expand_type.cpp
@@ -59,10 +59,10 @@ namespace {
     const auto& ti = crate.get_typeitem_by_path(sp, path.m_path);
     if(const auto* ep = ti.opt_TypeAlias() )
     {
-        const auto& ta = *ep;
+        const auto& ta = **ep;
         DEBUG(path << " -> type " << ta.m_params.fmt_args() << " = " << ta.m_type);
         auto pp = get_path_params(sp, ta.m_params, path, is_expr);
-        // Monomorphise the exapnded type using the created params
+        // Monomorphise the expanded type using the created params
         auto ms = MonomorphStatePtr(nullptr, &pp, nullptr);
         HIR::TypeRef rv = ms.monomorph_type(sp, ta.m_type);
         DEBUG(path << " -> " << path.m_path << pp << " -> " << rv);
@@ -96,7 +96,7 @@ std::vector<HIR::TraitPath> ConvertHIR_ExpandAliases_GetTraitExpansion_GP(const 
     const auto& ti = crate.get_typeitem_by_path(sp, path.m_path);
     if(const auto* ep = ti.opt_TraitAlias() )
     {
-        const auto& ta = *ep;
+        const auto& ta = **ep;
         auto pp = get_path_params(sp, ta.m_params, path, is_expr);
         auto ms = MonomorphStatePtr(nullptr, &pp, nullptr);
         std::vector<HIR::TraitPath> rv;
@@ -128,13 +128,13 @@ std::vector<HIR::TraitPath> ConvertHIR_ExpandAliases_GetTraitExpansion(const Spa
                     }
                     const auto& ti = crate.get_typeitem_by_path(sp, path.m_path);
                     if( const auto* t = ti.opt_Trait() ) {
-                        for(const auto& pt : t->m_parent_traits) {
+                        for(const auto& pt : (*t)->m_parent_traits) {
                             if( contains_trait(sp, crate, pt.m_path, des_path) )
                                 return true;
                         }
                     }
                     else if( const auto* t = ti.opt_TraitAlias() ) {
-                        for(const auto& pt : t->m_traits) {
+                        for(const auto& pt : (*t)->m_traits) {
                             if( contains_trait(sp, crate, pt.m_path, des_path) )
                                 return true;
                         }
@@ -325,7 +325,7 @@ public:
             if( !ti.is_Enum() ) {
                 ERROR(sp, E0000, "Expeted enum path in pattern binding, got " << ti.tag_str());
             }
-            const auto& enm = ti.as_Enum();
+            const auto& enm = *ti.as_Enum();
 
             auto gp2 = gp.clone();
             gp2.m_path += name;
@@ -365,12 +365,12 @@ public:
             const auto& ti = m_crate.get_typeitem_by_path(sp, gp.m_path, false, /*ignore_last*/true);
             if( ti.is_Enum() ) {
                 // Enum variant!
-                const auto& enm = ti.as_Enum();
+                const auto& enm = *ti.as_Enum();
 
                 gp.m_params.m_lifetimes.resize( enm.m_params.m_lifetimes.size() );
                 gp.m_params.m_types.resize( enm.m_params.m_types.size() );
 
-                auto idx = ti.as_Enum().find_variant(gp.m_path.components().back());
+                auto idx = enm.find_variant(gp.m_path.components().back());
                 return ::HIR::Pattern::PathBinding::make_Enum({ &enm, static_cast<unsigned>(idx) });
             }
         }

--- a/src/hir_conv/lifetime_elision.cpp
+++ b/src/hir_conv/lifetime_elision.cpp
@@ -241,7 +241,7 @@ namespace
             const HIR::GenericParams* gp = nullptr;
             if( p.m_path.components().size() > 1 ) {
                 if( const auto* e = m_resolve.m_crate.get_typeitem_by_path(sp, p.m_path, false, true).opt_Enum() ) {
-                    gp = &e->m_params;
+                    gp = &(*e)->m_params;
                 }
             }
             if( !gp ) {
@@ -253,13 +253,13 @@ namespace
                     TU_MATCH_HDRA( (ti), {)
                     TU_ARMA(Import, e) BUG(sp, "Unexpected reference to import - " << p);
                     TU_ARMA(Module, e) BUG(sp, "Unexpected reference to module - " << p);
-                    TU_ARMA(TypeAlias, e) { gp = &e.m_params; }
-                    TU_ARMA(TraitAlias, e) { gp = &e.m_params; }
+                    TU_ARMA(TypeAlias , e) { gp = &e->m_params; }
+                    TU_ARMA(TraitAlias, e) { gp = &e->m_params; }
                     TU_ARMA(ExternType, e) { gp = nullptr; }
-                    TU_ARMA(Enum  , e) { gp = &e.m_params; }
-                    TU_ARMA(Struct, e) { gp = &e.m_params; }
-                    TU_ARMA(Union , e) { gp = &e.m_params; }
-                    TU_ARMA(Trait , e) { gp = &e.m_params; }
+                    TU_ARMA(Enum  , e) { gp = &e->m_params; }
+                    TU_ARMA(Struct, e) { gp = &e->m_params; }
+                    TU_ARMA(Union , e) { gp = &e->m_params; }
+                    TU_ARMA(Trait , e) { gp = &e->m_params; }
                     }
                     } break;
                 case HIR::Visitor::PathContext::VALUE: {
@@ -268,7 +268,7 @@ namespace
                     TU_ARMA(Import, e) BUG(sp, "Unexpected reference to import - " << p);
                     TU_ARMA(Constant, e) { gp = nullptr; }
                     TU_ARMA(Static  , e) { gp = nullptr; }
-                    TU_ARMA(Function, e) { gp = &e.m_params; }
+                    TU_ARMA(Function, e) { gp = &e->m_params; }
                     TU_ARMA(StructConstant   , e) { gp = &m_resolve.m_crate.get_struct_by_path(sp, e.ty).m_params; }
                     TU_ARMA(StructConstructor, e) { gp = &m_resolve.m_crate.get_struct_by_path(sp, e.ty).m_params; }
                     }
@@ -449,13 +449,13 @@ namespace
                     TU_MATCH_HDRA( (ti), { )
                     TU_ARMA(Import, v) { BUG(sp, "Unexpected import: " << p->m_path); }
                     TU_ARMA(Module, v) { BUG(sp, "Unexpected module: " << p->m_path); }
-                    TU_ARMA(TypeAlias, v) { gp = &v.m_params; }
-                    TU_ARMA(TraitAlias, v) { gp = &v.m_params; }
+                    TU_ARMA(TypeAlias, v) { gp = &v->m_params; }
+                    TU_ARMA(TraitAlias, v) { gp = &v->m_params; }
                     TU_ARMA(ExternType, v) { gp = nullptr; }
-                    TU_ARMA(Enum, v) { gp = &v.m_params; }
-                    TU_ARMA(Struct, v) { gp = &v.m_params; }
-                    TU_ARMA(Union, v) { gp = &v.m_params; }
-                    TU_ARMA(Trait, v) { gp = &v.m_params; }
+                    TU_ARMA(Enum  , v) { gp = &v->m_params; }
+                    TU_ARMA(Struct, v) { gp = &v->m_params; }
+                    TU_ARMA(Union , v) { gp = &v->m_params; }
+                    TU_ARMA(Trait , v) { gp = &v->m_params; }
                     }
                     if(gp) {
                         p->m_params.m_lifetimes.resize( gp->m_lifetimes.size() );

--- a/src/hir_conv/resolve_ufcs.cpp
+++ b/src/hir_conv/resolve_ufcs.cpp
@@ -272,7 +272,7 @@ namespace resolve_ufcs {
                         if( gp.m_path.components().size() > 1 )
                         {
                             const auto& ent = upper_visitor.m_crate.get_typeitem_by_path(sp, gp.m_path, /*ign_crate*/false, true);
-                            if( ent.is_Enum() && ent.as_Enum().find_variant(gp.m_path.components().back()) != SIZE_MAX )
+                            if( ent.is_Enum() && ent.as_Enum()->find_variant(gp.m_path.components().back()) != SIZE_MAX )
                             {
                                 // Rewrite!
                                 m_replacement.reset(new ::HIR::ExprNode_TupleVariant(sp, mv$(gp), /*is_struct*/false, mv$(node.m_args)));
@@ -314,7 +314,7 @@ namespace resolve_ufcs {
                             const auto& ent = upper_visitor.m_crate.get_typeitem_by_path(sp, gp.m_path, /*ign_crate*/false, true);
                             if( ent.is_Enum() )
                             {
-                                const auto& enm = ent.as_Enum();
+                                const auto& enm = *ent.as_Enum();
                                 auto idx = enm.find_variant(gp.m_path.components().back());
                                 if( enm.m_data.is_Value() || enm.m_data.as_Data().at(idx).type == HIR::TypeRef::new_unit() )
                                 {
@@ -351,7 +351,7 @@ namespace resolve_ufcs {
                                 node.m_is_struct = false;
                                 auto enum_path = std::move(gp);
                                 auto var_name = enum_path.m_path.pop_component();
-                                auto enum_ty = HIR::TypeRef::new_path(std::move(enum_path), &ent.as_Enum());
+                                auto enum_ty = HIR::TypeRef::new_path(std::move(enum_path), &*ent.as_Enum());
                                 p = ::HIR::Path(std::move(enum_ty), std::move(var_name));
                             }
                         }
@@ -968,10 +968,10 @@ namespace resolve_ufcs {
                     auto& gp = e.val.as_Named().path.m_data.as_Generic();
                     if( const auto* enm_p = m_crate.get_typeitem_by_path(sp, gp.m_path, false, true).opt_Enum() )
                     {
-                        unsigned idx = enm_p->find_variant(gp.m_path.components().back());
+                        unsigned idx = (*enm_p)->find_variant(gp.m_path.components().back());
                         pat.m_data = ::HIR::Pattern::Data::make_PathValue({
                             mv$(gp),
-                            ::HIR::Pattern::PathBinding::make_Enum({enm_p, idx})
+                            ::HIR::Pattern::PathBinding::make_Enum({&**enm_p, idx})
                             });
                     }
                 }

--- a/src/hir_expand/closures.cpp
+++ b/src/hir_expand/closures.cpp
@@ -1200,8 +1200,8 @@ namespace {
             str.m_markings.is_copy = node.m_is_copy;
             ::HIR::SimplePath   closure_struct_path;
             const ::HIR::TypeItem* closure_struct_ptr;
-            ::std::tie(closure_struct_path, closure_struct_ptr) = m_out.new_type(CLOSURE_PATH_PREFIX, m_new_type_suffix, mv$(str));
-            const auto& closure_struct_ref = closure_struct_ptr->as_Struct();
+            ::std::tie(closure_struct_path, closure_struct_ptr) = m_out.new_type(CLOSURE_PATH_PREFIX, m_new_type_suffix, box$(str));
+            const auto& closure_struct_ref = *closure_struct_ptr->as_Struct();
 
             // Mark the object pathname in the closure.
             node.m_obj_ptr = &closure_struct_ref;
@@ -1637,13 +1637,13 @@ namespace {
             monomorph_cb.add_bounds(sp, m_resolve);
 
             // Create state index enum
-            auto state_idx_type = m_out.new_type("gen_state_idx#", m_new_type_suffix, ::HIR::Enum {
+            auto state_idx_type = m_out.new_type("gen_state_idx#", m_new_type_suffix, box$(::HIR::Enum {
                 ::HIR::GenericParams(),
                 false,
                 ::HIR::Enum::Repr(),
                 ::HIR::Enum::Class::make_Value({})
-                });
-            auto state_idx_ty = ::HIR::TypeRef::new_path( state_idx_type.first, &state_idx_type.second->as_Enum() );
+                }));
+            auto state_idx_ty = ::HIR::TypeRef::new_path( state_idx_type.first, &*state_idx_type.second->as_Enum() );
 
             // Create the captures structure here, and update it afterwards with the state
             // - The final entry in captures is the state, and is pre-filled with zeroes by the creator's MIR lower
@@ -1655,8 +1655,8 @@ namespace {
             state_str.m_data.as_Tuple().push_back(HIR::VisEnt<HIR::TypeRef> { HIR::Publicity::new_none(), state_idx_ty.clone() });
             ::HIR::SimplePath   state_struct_path;
             const ::HIR::TypeItem* state_struct_ptr;
-            ::std::tie(state_struct_path, state_struct_ptr) = m_out.new_type("gen_state#", m_new_type_suffix, std::move(state_str));
-            auto state_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, params.make_nop_params(0)), &state_struct_ptr->as_Struct() );
+            ::std::tie(state_struct_path, state_struct_ptr) = m_out.new_type("gen_state#", m_new_type_suffix, box$(state_str));
+            auto state_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, params.make_nop_params(0)), &*state_struct_ptr->as_Struct() );
             DEBUG("state_type = " << state_type);
             cr_vars.set_state_type(state_type.clone());
 
@@ -1668,15 +1668,15 @@ namespace {
             gen_str.m_markings.has_drop_impl = true;
             ::HIR::SimplePath   gen_struct_path;
             const ::HIR::TypeItem* gen_struct_ptr;
-            ::std::tie(gen_struct_path, gen_struct_ptr) = m_out.new_type(GENERATOR_PATH_PREFIX, m_new_type_suffix, mv$(gen_str));
-            const auto& gen_struct_ref = gen_struct_ptr->as_Struct();
+            ::std::tie(gen_struct_path, gen_struct_ptr) = m_out.new_type(GENERATOR_PATH_PREFIX, m_new_type_suffix, box$(gen_str));
+            const auto& gen_struct_ref = *gen_struct_ptr->as_Struct();
             DEBUG(gen_struct_path << " -> args=" << params.fmt_args() << " where " << params.fmt_bounds());
 
             // Mark the object pathname in the closure.
             node.m_obj_ptr = &gen_struct_ref;
             node.m_obj_path = ::HIR::GenericPath( gen_struct_path, monomorph_cb.freeze() );
             node.m_captures = std::move(cr_vars.capture_nodes);
-            node.m_state_data_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, node.m_obj_path.m_params.clone()), &state_struct_ptr->as_Struct() );
+            node.m_state_data_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, node.m_obj_path.m_params.clone()), &*state_struct_ptr->as_Struct() );
 
             auto lang_Pin = m_resolve.m_crate.get_lang_item_path(sp, "pin");
             // Return wrapper: Renamed in 1.90
@@ -1787,13 +1787,13 @@ namespace {
             monomorph_cb.add_bounds(sp, m_resolve);
 
             // Create state index enum
-            auto state_idx_type = m_out.new_type("async_state_idx#", m_new_type_suffix, ::HIR::Enum {
+            auto state_idx_type = m_out.new_type("async_state_idx#", m_new_type_suffix, box$(::HIR::Enum {
                 ::HIR::GenericParams(),
                 false,
                 ::HIR::Enum::Repr(),
                 ::HIR::Enum::Class::make_Value({})
-                });
-            auto state_idx_ty = ::HIR::TypeRef::new_path( state_idx_type.first, &state_idx_type.second->as_Enum() );
+                }));
+            auto state_idx_ty = ::HIR::TypeRef::new_path( state_idx_type.first, &*state_idx_type.second->as_Enum() );
 
             // Create the captures structure here, and update it afterwards with the state
             // - The final entry in captures is the state, and is pre-filled with zeroes by the creator's MIR lower
@@ -1805,8 +1805,8 @@ namespace {
             state_str.m_data.as_Tuple().push_back(HIR::VisEnt<HIR::TypeRef> { HIR::Publicity::new_none(), state_idx_ty.clone() });
             ::HIR::SimplePath   state_struct_path;
             const ::HIR::TypeItem* state_struct_ptr;
-            ::std::tie(state_struct_path, state_struct_ptr) = m_out.new_type("async_state#", m_new_type_suffix, std::move(state_str));
-            auto state_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, params.make_nop_params(0)), &state_struct_ptr->as_Struct() );
+            ::std::tie(state_struct_path, state_struct_ptr) = m_out.new_type("async_state#", m_new_type_suffix, box$(state_str));
+            auto state_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, params.make_nop_params(0)), &*state_struct_ptr->as_Struct() );
 
             // Update the state type entry, now that it's known
             cr_vars.set_state_type(state_type.clone());
@@ -1823,8 +1823,8 @@ namespace {
             gen_str.m_markings.has_drop_impl = true;
             ::HIR::SimplePath   gen_struct_path;
             const ::HIR::TypeItem* gen_struct_ptr;
-            ::std::tie(gen_struct_path, gen_struct_ptr) = m_out.new_type(PATH_PREFIX_FUTURE, m_new_type_suffix, mv$(gen_str));
-            const auto& gen_struct_ref = gen_struct_ptr->as_Struct();
+            ::std::tie(gen_struct_path, gen_struct_ptr) = m_out.new_type(PATH_PREFIX_FUTURE, m_new_type_suffix, box$(gen_str));
+            const auto& gen_struct_ref = *gen_struct_ptr->as_Struct();
 
             DEBUG(gen_struct_path << " -> args=" << params.fmt_args() << " where " << params.fmt_bounds());
 
@@ -1832,7 +1832,7 @@ namespace {
             node.m_obj_ptr = &gen_struct_ref;
             node.m_obj_path = ::HIR::GenericPath( gen_struct_path, monomorph_cb.freeze() );
             node.m_captures = std::move(cr_vars.capture_nodes);
-            node.m_state_data_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, node.m_obj_path.m_params.clone()), &state_struct_ptr->as_Struct() );
+            node.m_state_data_type = ::HIR::TypeRef::new_path( ::HIR::GenericPath(state_struct_path, node.m_obj_path.m_params.clone()), &*state_struct_ptr->as_Struct() );
 
             ::HIR::TypeRef& self_arg_ty = cr_vars.new_locals[0];
             // `::path::to::struct`
@@ -1956,12 +1956,14 @@ namespace {
             ::HIR::SimplePath   root_mod_path(crate.m_crate_name,{});
             m_cur_mod_path = &root_mod_path;
             // Type construction helper used for impl blocks
-            m_out.new_type = [&](const char* prefix, const char* suffix, auto s)->auto {
+            m_out.new_type = [&](const char* prefix, const char* suffix, ::HIR::TypeItem s)->auto {
                 auto name = RcString::new_interned(FMT(prefix << "I_" << suffix << (suffix[0] ? "_" : "") << closure_count));
                 closure_count += 1;
-                auto boxed = box$(( ::HIR::VisEnt< ::HIR::TypeItem> { ::HIR::Publicity::new_none(), mv$(s) } ));
-                auto* ret_ptr = &boxed->ent;
-                crate.m_root_module.m_mod_items.insert( ::std::make_pair(name, mv$(boxed)) );
+                auto r = crate.m_root_module.m_mod_items.insert( ::std::make_pair(
+                    name,
+                    ::HIR::VisEnt< ::HIR::TypeItem> { ::HIR::Publicity::new_none(), mv$(s) }
+                ) );
+                auto* ret_ptr = &r.first->second.ent;
                 return ::std::make_pair( ::HIR::SimplePath(crate.m_crate_name, {}) + name, ret_ptr );
                 };
 
@@ -2005,7 +2007,7 @@ namespace {
             for(auto& e : new_types)
             {
                 DEBUG(p << ": Push " << e.first);
-                mod.m_mod_items.insert( mv$(e) );
+                mod.m_mod_items.insert( ::std::make_pair(e.first, mv$(*e.second)) );
             }
             // Fix module paths on all impls created during this call that haven't already had a path set
             // - Child modules will set paths on theirs
@@ -2159,12 +2161,11 @@ void HIR_Expand_Closures_Expr(const ::HIR::Crate& crate_ro, ::HIR::TypeRef& exp_
 
     static int closure_count = 0;
     OutState    out;
-    out.new_type = [&](const char* prefix, const char* suffix, auto s)->auto {
+    out.new_type = [&](const char* prefix, const char* suffix, ::HIR::TypeItem s)->auto {
         auto name = RcString::new_interned(FMT(prefix << "C_" << closure_count));
         closure_count += 1;
-        auto boxed = box$(( ::HIR::VisEnt< ::HIR::TypeItem> { ::HIR::Publicity::new_none(), ::HIR::TypeItem( mv$(s) ) } ));
-        auto* ret_ptr = &boxed->ent;
-        crate.m_new_types.push_back( ::std::make_pair(name, mv$(boxed)) );
+        crate.m_new_types.push_back(::std::make_pair(name, ::HIR::VisEnt< ::HIR::TypeItem> { ::HIR::Publicity::new_none(), mv$(s) } ));
+        auto* ret_ptr = &crate.m_new_types.back().second.ent;
         return ::std::make_pair( ::HIR::SimplePath(crate.m_crate_name, {}) + name, ret_ptr );
         };
 

--- a/src/hir_expand/static_borrow_constants.cpp
+++ b/src/hir_expand/static_borrow_constants.cpp
@@ -1141,10 +1141,10 @@ namespace static_borrow_constants {
                         new_static.m_value_generated = true;
                         new_static.m_value_res = ::std::move(value);
                         DEBUG(path << " = " << new_static.m_value_res);
-                        m_current_module.m_value_items.insert(std::make_pair( name, box$(HIR::VisEnt<HIR::ValueItem> {
+                        m_current_module.m_value_items.insert(std::make_pair( name, HIR::VisEnt<HIR::ValueItem> {
                                 HIR::Publicity::new_none(), // Should really be private, but we're well after checking
-                                HIR::ValueItem(::std::move(new_static))
-                            })) );
+                                HIR::ValueItem(box$(new_static))
+                            }) );
                         return path;
                     }
                 } nvs { mod_path, mod, mod_list.second.size() };
@@ -1177,12 +1177,13 @@ namespace static_borrow_constants {
                         }
                     };
                     auto new_ent = new_static_pair.is_const
-                        ? HIR::ValueItem(H::to_const(new_static))
-                        : HIR::ValueItem(std::move(new_static_pair.data));
-                    mod.m_value_items.insert(std::make_pair( mv$(new_static_pair.path.components().back()), box$(HIR::VisEnt<HIR::ValueItem> {
+                        ? HIR::ValueItem(box$(H::to_const(new_static)))
+                        : HIR::ValueItem(box$(new_static_pair.data))
+                        ;
+                    mod.m_value_items.insert(std::make_pair( mv$(new_static_pair.path.components().back()), HIR::VisEnt<HIR::ValueItem> {
                         HIR::Publicity::new_none(), // Should really be private, but we're well after checking
                         std::move(new_ent)
-                        })) );
+                        }) );
                 }
             }
         }
@@ -1384,12 +1385,12 @@ void HIR_Expand_StaticBorrowConstants_Expr(const ::HIR::Crate& crate, const ::HI
                 new_static.m_value_generated = true;
                 new_static.m_value_res = ::std::move(value);
                 DEBUG(path << " = " << new_static.m_value_res);
-                crate.m_new_values.push_back(std::make_pair( name, box$(HIR::VisEnt<HIR::ValueItem> {
+                crate.m_new_values.push_back(std::make_pair( name, HIR::VisEnt<HIR::ValueItem> {
                     HIR::Publicity::new_none(), // Should really be private, but we're well after checking
-                    HIR::ValueItem(::std::move(new_static))
-                }) ));
+                    HIR::ValueItem(box$(new_static))
+                } ));
 
-                auto& s = crate.m_new_values.back().second->ent.as_Static();
+                auto& s = *crate.m_new_values.back().second.ent.as_Static();
                 ASSERT_BUG(Span(), !s.m_value.m_state, "ExprState set already");
                 s.m_value.m_state = ::HIR::ExprStatePtr(::HIR::ExprState(crate.m_root_module, ::HIR::SimplePath(crate.m_crate_name)));
                 s.m_value.m_state->stage = ::HIR::ExprState::Stage::Sbc;
@@ -1408,16 +1409,16 @@ void HIR_Expand_StaticBorrowConstants_Expr(const ::HIR::Crate& crate, const ::HI
 
         DEBUG(path << " = ?");
         auto vi = is_const
-            ? HIR::ValueItem(HIR::Constant { std::move(new_static.m_params), std::move(new_static.m_type), std::move(new_static.m_value) })
-            : HIR::ValueItem(std::move(new_static))
+            ? HIR::ValueItem(box$(HIR::Constant { std::move(new_static.m_params), std::move(new_static.m_type), std::move(new_static.m_value) }))
+            : HIR::ValueItem(box$(new_static))
             ;
-        auto boxed = box$(( ::HIR::VisEnt< ::HIR::ValueItem> { ::HIR::Publicity::new_none(), std::move(vi) } ));
+        auto boxed = ::HIR::VisEnt< ::HIR::ValueItem> { ::HIR::Publicity::new_none(), std::move(vi) };
         crate.m_new_values.push_back( ::std::make_pair(name, mv$(boxed)) );
         {
-            auto& e = crate.m_new_values.back().second->ent;
+            auto& e = crate.m_new_values.back().second.ent;
             ASSERT_BUG(sp, e.is_Static() || e.is_Constant(), "");
-            auto& p = e.is_Static() ? e.as_Static().m_params : e.as_Constant().m_params;
-            auto& v = e.is_Static() ? e.as_Static().m_value : e.as_Constant().m_value;
+            auto& p = e.is_Static() ? e.as_Static()->m_params : e.as_Constant()->m_params;
+            auto& v = e.is_Static() ? e.as_Static()->m_value : e.as_Constant()->m_value;
             ASSERT_BUG(Span(), v.m_state, "");
             v.m_state->m_impl_generics = nullptr;
             v.m_state->m_item_generics = &p;

--- a/src/hir_expand/vtable.cpp
+++ b/src/hir_expand/vtable.cpp
@@ -168,8 +168,11 @@ namespace {
             auto saved_nt = mv$(m_new_type);
 
             ::std::vector< decltype(mod.m_mod_items)::value_type> new_types;
-            m_new_type = [&](bool pub, auto name, auto s)->auto {
-                auto boxed = box$( (::HIR::VisEnt< ::HIR::TypeItem> { (pub ? ::HIR::Publicity::new_global() : ::HIR::Publicity::new_none()), ::HIR::TypeItem( mv$(s) ) }) );
+            m_new_type = [&](bool pub, auto name, HIR::Struct s)->auto {
+                auto boxed = ::HIR::VisEnt< ::HIR::TypeItem> {
+                    (pub ? ::HIR::Publicity::new_global() : ::HIR::Publicity::new_none()),
+                    ::HIR::TypeItem( box$(s) )
+                };
                 auto ret = (p + name).get_simple_path();
                 new_types.push_back( ::std::make_pair( mv$(name), mv$(boxed)) );
                 return ret;

--- a/src/hir_typeck/expr_cs__enum.cpp
+++ b/src/hir_typeck/expr_cs__enum.cpp
@@ -1233,13 +1233,13 @@ namespace typecheck
             {
                 const auto& e = this->context.m_crate.get_typeitem_by_path(sp, gp.m_path);
                 if( e.is_Struct() ) {
-                    const auto& str = e.as_Struct();
+                    const auto& str = *e.as_Struct();
                     fix_param_count(sp, this->context, ::HIR::TypeRef(), false, gp, str.m_params, gp.m_params);
 
                     return ::HIR::TypeRef::new_path( gp.clone(), ::HIR::TypePathBinding::make_Struct(&str) );
                 }
                 else if( e.is_Union() ) {
-                    const auto& u = e.as_Union();
+                    const auto& u = *e.as_Union();
                     fix_param_count(sp, this->context, ::HIR::TypeRef(), false, gp, u.m_params, gp.m_params);
 
                     return ::HIR::TypeRef::new_path( gp.clone(), ::HIR::TypePathBinding::make_Union(&u) );

--- a/src/hir_typeck/expr_visit.cpp
+++ b/src/hir_typeck/expr_visit.cpp
@@ -31,7 +31,7 @@ namespace typeck {
                 if( ip.parent )
                 {
                     const auto& mod = H::get_mod_for_ip(crate, *ip.parent);
-                    return mod.m_mod_items.at(ip.name)->ent.as_Module();
+                    return *mod.m_mod_items.at(ip.name).ent.as_Module();
                 }
                 else
                 {
@@ -84,17 +84,17 @@ namespace typeck {
             // Namespace path
             const auto& mod = H::get_mod_for_ip(m_crate, *ip.parent);
             H::add_traits_from_mod(*this, mod);
-            const auto& item = mod.m_value_items.at(ip.name)->ent;
+            const auto& item = mod.m_value_items.at(ip.name).ent;
             m_impl_generics = nullptr;
             TU_MATCH_HDRA( (item), { )
             TU_ARMA(Constant, e) {
-                m_item_generics = &e.m_params;
+                m_item_generics = &e->m_params;
                 }
             TU_ARMA(Static, e) {
-                //m_item_generics = &e.m_params;
+                //m_item_generics = &e->m_params;
                 }
             TU_ARMA(Function, e) {
-                m_item_generics = &e.m_params;
+                m_item_generics = &e->m_params;
                 }
             TU_ARMA(StructConstant, _e) BUG(sp, ip << " is StructConstant");
             TU_ARMA(StructConstructor, _e) BUG(sp, ip << " is StructConstructor");

--- a/src/hir_typeck/outer.cpp
+++ b/src/hir_typeck/outer.cpp
@@ -18,7 +18,7 @@ namespace {
         {
             const auto& pitem = crate.get_typeitem_by_path(sp, path, false, true);
             if(pitem.is_Enum() ) {
-                return pitem.as_Enum().m_params;
+                return pitem.as_Enum()->m_params;
             }
         }
 
@@ -32,14 +32,14 @@ namespace {
                 BUG(sp, "Value path pointed to import - " << path << " = " << e.path);
                 ),
             (Function,
-                return e.m_params;
+                return e->m_params;
                 ),
             (Constant,
-                return e.m_params;
+                return e->m_params;
                 ),
             (Static,
                 // TODO: Return an empty set?
-                BUG(sp, "Attepted to get parameters for static " << path);
+                BUG(sp, "Attempted to get parameters for static " << path);
                 ),
             (StructConstructor,
                 return get_params_for_item(sp, crate, e.ty, ::HIR::Visitor::PathContext::TYPE);
@@ -72,16 +72,16 @@ namespace {
                 BUG(sp, "Type path pointed to module - " << path);
                 ),
             (Struct,
-                return e.m_params;
+                return e->m_params;
                 ),
             (Enum,
-                return e.m_params;
+                return e->m_params;
                 ),
             (Union,
-                return e.m_params;
+                return e->m_params;
                 ),
             (Trait,
-                return e.m_params;
+                return e->m_params;
                 )
             )
             } break;
@@ -682,7 +682,7 @@ namespace {
                     }
                 //(NotTrait, e) {
                 //    ::HIR::TypeRef  type;
-                //    ::HIR::GenricPath    trait;
+                //    ::HIR::GenericPath    trait;
                 //    }),
                 TU_ARMA(TypeEquality, e) {
                     this->visit_type(e.type);
@@ -757,13 +757,13 @@ namespace {
 
                 const HIR::GenericParams* params = nullptr;
                 if(const auto* e = ti.opt_Struct()) {
-                    params = &e->m_params;
+                    params = &(*e)->m_params;
                 }
                 else if(const auto* e = ti.opt_Enum()) {
-                    params = &e->m_params;
+                    params = &(*e)->m_params;
                 }
                 else if(const auto* e = ti.opt_Union()) {
-                    params = &e->m_params;
+                    params = &(*e)->m_params;
                 }
                 else {
                     DEBUG("TODO: Obtain bounds from " << ti.tag_str());
@@ -827,7 +827,7 @@ namespace {
             m_self_types.pop_back();
 
             // TODO: Check that the type+trait is valid
-            // - And fix bad elided liftimes (match annotations if they were elided)
+            // - And fix bad elided lifetimes (match annotations if they were elided)
             {
                 const auto& trait = m_resolve.m_crate.get_trait_by_path(sp, trait_path);
                 for(auto& e : impl.m_methods)

--- a/src/hir_typeck/static.cpp
+++ b/src/hir_typeck/static.cpp
@@ -3392,19 +3392,17 @@ StaticTraitResolve::ValuePtr StaticTraitResolve::get_value(const Span& sp, const
             const auto& ti = m_crate.get_typeitem_by_path(sp, pe.m_path, /*ignore_crate_name=*/false, /*ignore_last_node=*/true);
             if( const auto* e = ti.opt_Enum() )
             {
+                const auto& enm = **e;
                 if(out_impl_params_def) {
-                    *out_impl_params_def = &e->m_params;
+                    *out_impl_params_def = &enm.m_params;
                 }
                 out_params.pp_impl = &pe.m_params;
-                auto idx = e->find_variant(pe.m_path.components().back());
-                if( e->m_data.is_Data() )
+                auto idx = enm.find_variant(pe.m_path.components().back());
+                if( enm.m_data.is_Data() && enm.m_data.as_Data()[idx].type != ::HIR::TypeRef::new_unit() )
                 {
-                    if( e->m_data.as_Data()[idx].type != ::HIR::TypeRef::new_unit() )
-                    {
-                        return ValuePtr::Data_EnumConstructor { e, idx };
-                    }
+                    return ValuePtr::Data_EnumConstructor { &enm, idx };
                 }
-                return ValuePtr::Data_EnumValue { e, idx };
+                return ValuePtr::Data_EnumValue { &enm, idx };
             }
         }
         const auto& v = m_crate.get_valitem_by_path(sp, pe.m_path);
@@ -3412,15 +3410,15 @@ StaticTraitResolve::ValuePtr StaticTraitResolve::get_value(const Span& sp, const
         (Import, BUG(sp, "Module Import");),
         (Constant,
             out_params.pp_method = &pe.m_params;
-            return &ve;
+            return &*ve;
             ),
         (Static,
             out_params.pp_method = &pe.m_params;
-            return &ve;
+            return &*ve;
             ),
         (Function,
             out_params.pp_method = &pe.m_params;
-            return &ve;
+            return &*ve;
             ),
         (StructConstant,
             out_params.pp_impl = &pe.m_params;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -768,11 +768,11 @@ int main(int argc, char *argv[])
                 crate_for_ser.m_crate_name = hir_crate->m_crate_name;
                 crate_for_ser.m_edition    = hir_crate->m_edition;
                 for(const auto& i : hir_crate->m_root_module.m_macro_items) {
-                    DEBUG(i.first << ": " << i.second->ent.tag_str());
-                    if( const auto* e = i.second->ent.opt_ProcMacro() ) {
+                    DEBUG(i.first << ": " << i.second.ent.tag_str());
+                    if( const auto* e = i.second.ent.opt_ProcMacro() ) {
                         crate_for_ser.m_root_module.m_macro_items.insert(std::make_pair(
                             i.first,
-                            box$(HIR::VisEnt<HIR::MacroItem>{ i.second->publicity, *e })
+                            HIR::VisEnt<HIR::MacroItem>{ i.second.publicity, box$(**e) }
                             ));
                     }
                 }

--- a/src/memory_dump.cpp
+++ b/src/memory_dump.cpp
@@ -89,6 +89,7 @@ void memory_dump(const char* phase)
             ::std::string   name;
             uint32_t first_chunk;
         };
+        // Default to a 1MiB chunk size
         size_t chunk_size = 1 << 20;
         ::std::vector<RangeEnt> range_ents;
         size_t chunk_count = 0;

--- a/src/mir/cleanup.cpp
+++ b/src/mir/cleanup.cpp
@@ -515,7 +515,7 @@ namespace {
                 return ::MIR::Constant( mv$(bytestr) );
             }
             else if( te.inner == ::HIR::CoreType::Str ) {
-                return ::MIR::Constant::make_StaticString(std::string(s,e));
+                return ::MIR::Constant::make_StaticString(RcString(&*s,static_cast<size_t>(e-s)));
             }
             else {
                 // Get repr, assert that there's only one field and it's a `[u8]` or `str`

--- a/src/mir/dump.cpp
+++ b/src/mir/dump.cpp
@@ -182,7 +182,7 @@ namespace {
                         ),
                     (String,
                         for(unsigned int j = 0; j < e.targets.size(); j ++)
-                            m_os << "\"" << FmtEscaped(ve[j]) << "\" => bb" << e.targets[j] << ", ";
+                            m_os << "\"" << FmtEscaped(ve[j].c_str(), ve[j].size()) << "\" => bb" << e.targets[j] << ", ";
                         ),
                     (ByteString,
                         for(unsigned int j = 0; j < e.targets.size(); j ++) {

--- a/src/mir/from_hir.cpp
+++ b/src/mir/from_hir.cpp
@@ -2632,7 +2632,7 @@ namespace {
                 m_builder.set_result(node.span(), ::MIR::RValue::make_Constant( ::MIR::Constant::make_Bool({e}) ));
                 }
             TU_ARMA(String, e) {
-                m_builder.set_result(node.span(), ::MIR::RValue::make_Constant( ::MIR::Constant(e) ));
+                m_builder.set_result(node.span(), ::MIR::RValue::make_Constant( ::MIR::Constant(RcString(e)) ));
                 }
             TU_ARMA(CString, e) {
                 auto s = e.v;
@@ -2649,7 +2649,7 @@ namespace {
                 m_builder.end_block(::MIR::Terminator::make_Call({
                     cast__ok, cast__panic,
                     res.clone(), ::MIR::CallTarget::make_Intrinsic({ "transmute", mv$(transmute_params) }),
-                    make_vec1( ::MIR::Param( ::MIR::Constant(std::move(s)) ) )
+                    make_vec1( ::MIR::Param( ::MIR::Constant(RcString(s)) ) )
                     }));
                 m_builder.set_cur_block(cast__panic);
                 emit_unwind(node.span());

--- a/src/mir/from_hir.cpp
+++ b/src/mir/from_hir.cpp
@@ -2722,7 +2722,7 @@ namespace {
                     BUG(sp, "All references via imports should be replaced");
                     }
                 TU_ARMA(Constant, e) {
-                    auto ty = MonomorphStatePtr(nullptr, nullptr, &pe.m_params).monomorph_type(sp, e.m_type);
+                    auto ty = MonomorphStatePtr(nullptr, nullptr, &pe.m_params).monomorph_type(sp, e->m_type);
                     auto tmp = m_builder.new_temporary( ty );
                     m_builder.push_stmt_assign( sp, tmp.clone(), ::MIR::Constant::make_Const({box$(node.m_path.clone())}) );
                     m_builder.set_result( node.span(), mv$(tmp) );

--- a/src/mir/from_hir_match.cpp
+++ b/src/mir/from_hir_match.cpp
@@ -1328,7 +1328,7 @@ void PatternRulesetBuilder::append_from_lit(const Span& sp, EncodedLiteralSlice 
             ASSERT_BUG(sp, len <= r->bytes.size(), "");
             ASSERT_BUG(sp, ptr+len <= r->bytes.size(), "");
 
-            this->push_rule(PatternRule::make_Value( std::string(r->bytes.data() + ptr, r->bytes.data() + ptr + len) ));
+            this->push_rule(PatternRule::make_Value( RcString(r->bytes.data() + ptr, len) ));
         }
         else if( e.inner.data().is_Slice() && e.inner.data().as_Slice().inner == ::HIR::CoreType::U8 ) {
             auto ptr_size = Target_GetPointerBits()/8;
@@ -2136,7 +2136,7 @@ void PatternRulesetBuilder::append_from(const Span& sp, const ::HIR::Pattern& pa
             // TODO: Check type?
             if( pe.val.is_String() ) {
                 const auto& s = pe.val.as_String();
-                this->push_rule( PatternRule::make_Value(s) );
+                this->push_rule( PatternRule::make_Value(RcString(s)) );
             }
             else if( pe.val.is_ByteString() ) {
                 const auto& s = pe.val.as_ByteString().v;
@@ -3857,7 +3857,7 @@ void MatchGenGrouped::gen_dispatch__primitive(::HIR::TypeRef ty, ::MIR::LValue v
         val.m_wrappers.pop_back();
 
         ::std::vector< ::MIR::BasicBlockId> targets;
-        ::std::vector< ::std::string>   values;
+        ::std::vector< RcString>   values;
         size_t tgt_ofs = 0;
         for(size_t i = 0; i < rules.size(); i++)
         {

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -48,7 +48,7 @@ namespace MIR {
             os << ::std::dec;
             ),
         (StaticString,
-            os << "\"" << FmtEscaped(e) << "\"";
+            os << "\"" << FmtEscaped(e.c_str(), e.size()) << "\"";
             ),
         (Const,
             assert(e.p);

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -471,7 +471,7 @@ TAGGED_UNION_EX(Constant, (), Int, (
         bool    v;  // NOTE: Defensive to prevent implicit casts
         }),
     (Bytes, ::std::vector< ::std::uint8_t>),    // Byte string
-    (StaticString, ::std::string),  // String
+    (StaticString, RcString),   // A non-interned rc-string, as MIR gets copied sometimes. `std::string` is 4 words, larger than the integers
     // NOTE: These are behind pointers to save inline space (HIR::Path is ~11
     // words, compared to 4 for MIR::Constant without it)
     (Const, struct { ::std::unique_ptr<::HIR::Path> p; }),   // `const`
@@ -603,7 +603,7 @@ TAGGED_UNION(CallTarget, Intrinsic,
 TAGGED_UNION_EX(SwitchValues, (), Unsigned, (
     (Unsigned, ::std::vector<uint64_t>),
     (Signed, ::std::vector<int64_t>),
-    (String, ::std::vector<::std::string>),
+    (String, ::std::vector<RcString>),
     (ByteString, ::std::vector<::std::vector<uint8_t>>)
     ), (),(), (
         SwitchValues clone() const;

--- a/src/resolve/absolute.cpp
+++ b/src/resolve/absolute.cpp
@@ -496,9 +496,9 @@ namespace
                     for(const auto& n : mp.ents)
                     {
                         ASSERT_BUG(sp, mod->m_mod_items.count(n), "Node `" << n << "` missing in path " << mp);
-                        const auto& i = *mod->m_mod_items.at(n);
+                        const auto& i = mod->m_mod_items.at(n);
                         ASSERT_BUG(sp, i.ent.is_Module(), "Node `" << n << "` not a module in path " << mp);
-                        mod = &i.ent.as_Module();
+                        mod = &*i.ent.as_Module();
                     }
                     AST::Path::Bindings bindings;
                     const HIR::SimplePath* true_path = nullptr;
@@ -509,7 +509,7 @@ namespace
                     case LookupMode::Variable: {
                         auto it = mod->m_value_items.find(name);
                         if(it != mod->m_value_items.end()) {
-                            const auto* item = &it->second->ent;
+                            const auto* item = &it->second.ent;
                             auto item_path = AST::AbsolutePath(mp.crate, mp.ents) + name;
                             if( item->is_Import() ) {
                                 const auto& imp = item->as_Import();
@@ -544,7 +544,7 @@ namespace
                     case LookupMode::Type: {
                         auto it = mod->m_mod_items.find(name);
                         if( it != mod->m_mod_items.end() ) {
-                            const auto* item = &it->second->ent;
+                            const auto* item = &it->second.ent;
                             auto item_path = AST::AbsolutePath(mp.crate, mp.ents) + name;
                             if( item->is_Import() ) {
                                 const auto& imp = item->as_Import();
@@ -566,7 +566,7 @@ namespace
                             default:
                                 TODO(sp, "Bind type/mod '" << name << "' for module path " << mp << " : " << item->tag_str());
                             TU_ARMA(Module, e) {
-                                bindings.type.set( item_path, AST::PathBinding_Type::make_Module({nullptr, { &crate, &e }}) );
+                                bindings.type.set( item_path, AST::PathBinding_Type::make_Module({nullptr, { &crate, &*e }}) );
                                 }
                             TU_ARMA(Trait, e) {
                                 bindings.type.set( item_path, AST::PathBinding_Type::make_Trait({nullptr}) );
@@ -1125,15 +1125,15 @@ namespace {
             if( it == hmod->m_mod_items.end() )
                 ERROR(sp, E0000, "Couldn't find path component '" << name << "' of " << p);
 
-            TU_MATCH_HDRA( (it->second->ent), {)
+            TU_MATCH_HDRA( (it->second.ent), {)
             default:
-                TODO(sp, "Unknown item type in path - " << i << " " << p << " - " << it->second->ent.tag_str());
+                TODO(sp, "Unknown item type in path - " << i << " " << p << " - " << it->second.ent.tag_str());
             TU_ARMA(Enum, e) {
                 if( i != p.components().size() - 2 ) {
                     ERROR(sp, E0000, "Enum as path component in unexpected location - " << p);
                 }
                 const auto& varname = p.components().back();
-                auto var_idx = e.find_variant(varname);
+                auto var_idx = e->find_variant(varname);
                 ASSERT_BUG(sp, var_idx != SIZE_MAX, "Extern crate import path points to non-present variant - " << p);
 
                 // Construct output path (with same set of parameters)
@@ -1143,18 +1143,18 @@ namespace {
                     rv.nodes().push_back( AST::PathNode(c) );
                 rv.nodes().back().args() = mv$( path.nodes().back().args() );
                 auto ap = sp_to_ap(p);
-                if( e.m_data.is_Data() && e.m_data.as_Data()[var_idx].is_struct ) {
-                    rv.m_bindings.type.set( ap, ::AST::PathBinding_Type::make_EnumVar({nullptr, static_cast<unsigned>(var_idx), &e}) );
+                if( e->m_data.is_Data() && e->m_data.as_Data()[var_idx].is_struct ) {
+                    rv.m_bindings.type.set( ap, ::AST::PathBinding_Type::make_EnumVar({nullptr, static_cast<unsigned>(var_idx), &*e}) );
                 }
                 else {
-                    rv.m_bindings.value.set( ap, ::AST::PathBinding_Value::make_EnumVar({nullptr, static_cast<unsigned>(var_idx), &e}) );
+                    rv.m_bindings.value.set( ap, ::AST::PathBinding_Value::make_EnumVar({nullptr, static_cast<unsigned>(var_idx), &*e}) );
                 }
                 path = mv$(rv);
 
                 return ;
                 }
             TU_ARMA(Module, e) {
-                hmod = &e;
+                hmod = &*e;
                 }
             }
         }
@@ -1169,7 +1169,7 @@ namespace {
             if( it == hmod->m_value_items.end() )
                 ERROR(sp, E0000, "Couldn't find final component of " << p);
             AST::PathBinding_Value  pbv;
-            TU_MATCH_HDRA( (it->second->ent), {)
+            TU_MATCH_HDRA( (it->second.ent), {)
             TU_ARMA(Import, e) {
                 // Wait? is this even valid?
                 BUG(sp, "HIR Import item pointed to an import");
@@ -1178,16 +1178,16 @@ namespace {
                 pbv = ::AST::PathBinding_Value::make_Static({nullptr, nullptr});
                 }
             TU_ARMA(Static, e) {
-                pbv = ::AST::PathBinding_Value::make_Static({nullptr, &e});
+                pbv = ::AST::PathBinding_Value::make_Static({nullptr, &*e});
                 }
             TU_ARMA(StructConstant, e) {
-                pbv = ::AST::PathBinding_Value::make_Struct({nullptr, &ext_crate.m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct()});
+                pbv = ::AST::PathBinding_Value::make_Struct({nullptr, &*ext_crate.m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct()});
                 }
             TU_ARMA(Function, e) {
-                pbv = ::AST::PathBinding_Value::make_Function({nullptr/*, &e*/});
+                pbv = ::AST::PathBinding_Value::make_Function({nullptr/*, &*e*/});
                 }
             TU_ARMA(StructConstructor, e) {
-                pbv = ::AST::PathBinding_Value::make_Struct({nullptr, &ext_crate.m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct()});
+                pbv = ::AST::PathBinding_Value::make_Struct({nullptr, &*ext_crate.m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct()});
                 }
             }
             pb.value.set( ::std::move(ap), ::std::move(pbv) );
@@ -1198,34 +1198,34 @@ namespace {
             if( it == hmod->m_mod_items.end() )
                 ERROR(sp, E0000, "Couldn't find final component of " << p);
             AST::PathBinding_Type   pbt;
-            TU_MATCH_HDRA( (it->second->ent), {)
+            TU_MATCH_HDRA( (it->second.ent), {)
             TU_ARMA(Import, e) {
                 // Wait? is this even valid?
                 BUG(sp, "HIR Import item pointed to an import");
                 }
             TU_ARMA(Module, e) {
-                pbt = ::AST::PathBinding_Type::make_Module({nullptr, {&ext_crate, &e}});
+                pbt = ::AST::PathBinding_Type::make_Module({nullptr, {&ext_crate, &*e}});
                 }
             TU_ARMA(Trait, e) {
-                pbt = ::AST::PathBinding_Type::make_Trait({nullptr, &e});
+                pbt = ::AST::PathBinding_Type::make_Trait({nullptr, &*e});
                 }
             TU_ARMA(TraitAlias, e) {
-                pbt = ::AST::PathBinding_Type::make_TraitAlias({nullptr, &e});
+                pbt = ::AST::PathBinding_Type::make_TraitAlias({nullptr, &*e});
                 }
             TU_ARMA(TypeAlias, e) {
-                pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &e*/});
+                pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &*e*/});
                 }
             TU_ARMA(ExternType, e) {
-                pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &e*/});
+                pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &*e*/});
                 }
             TU_ARMA(Struct, e) {
-                pbt = ::AST::PathBinding_Type::make_Struct({nullptr, &e});
+                pbt = ::AST::PathBinding_Type::make_Struct({nullptr, &*e});
                 }
             TU_ARMA(Union, e) {
-                pbt = ::AST::PathBinding_Type::make_Union({nullptr, &e});
+                pbt = ::AST::PathBinding_Type::make_Union({nullptr, &*e});
                 }
             TU_ARMA(Enum, e) {
-                pbt = ::AST::PathBinding_Type::make_Enum({nullptr, &e});
+                pbt = ::AST::PathBinding_Type::make_Enum({nullptr, &*e});
                 }
             }
             pb.type.set( ::std::move(ap), ::std::move(pbt) );
@@ -1267,7 +1267,7 @@ namespace {
             if( it == hmod->m_mod_items.end() )
                 ERROR(sp, E0000, "Couldn't find path component '" << n.name() << "' of " << path);
 
-            TU_MATCH_HDRA( (it->second->ent), {)
+            TU_MATCH_HDRA( (it->second.ent), {)
             TU_ARMA(Import, e) {
                 DEBUG("`" << n.name() << "`: Import " << e.path);
                 // - Update path then restart
@@ -1289,7 +1289,7 @@ namespace {
                 return ;
                 }
             TU_ARMA(Module, e) {
-                hmod = &e;
+                hmod = &*e;
                 }
             TU_ARMA(TraitAlias, e) {
                 //for(const auto& trait_path_hir : e.m_traits)
@@ -1306,14 +1306,14 @@ namespace {
                     pp = mv$(n.args());
                 }
                 else {
-                    for(const auto& typ : e.m_params.m_types)
+                    for(const auto& typ : e->m_params.m_types)
                     {
                         (void)typ;
                         pp.m_entries.push_back( ::TypeRef(sp) );
                     }
                 }
                 AST::Path   trait_path(ap, std::move(pp));
-                trait_path.m_bindings.type.set( ::std::move(ap), ::AST::PathBinding_Type::make_Trait({nullptr, &e}) );
+                trait_path.m_bindings.type.set( ::std::move(ap), ::AST::PathBinding_Type::make_Trait({nullptr, &*e}) );
 
                 ::AST::Path new_path;
                 const auto& next_node = path_abs.nodes[i+1];
@@ -1325,11 +1325,11 @@ namespace {
                 case Context::LookupMode::Namespace:
                 case Context::LookupMode::Type:
                 case Context::LookupMode::PatternType:
-                    found = (e.m_types.find( next_node.name() ) != e.m_types.end());
+                    found = (e->m_types.find( next_node.name() ) != e->m_types.end());
                 case Context::LookupMode::PatternValue:
                 case Context::LookupMode::Constant:
                 case Context::LookupMode::Variable:
-                    found = (e.m_values.find( next_node.name() ) != e.m_values.end());
+                    found = (e->m_values.find( next_node.name() ) != e->m_values.end());
                     break;
                 }
 
@@ -1358,7 +1358,7 @@ namespace {
                     auto& next_node = path_abs.nodes[i+1];
                     // If this refers to an enum variant, return the full path
                     // - Otherwise, assume it's an associated type?
-                    auto idx = e.find_variant(next_node.name());
+                    auto idx = e->find_variant(next_node.name());
                     if( idx != SIZE_MAX )
                     {
                         if( i != path_abs.nodes.size() - 2 ) {
@@ -1381,11 +1381,11 @@ namespace {
                             }
                         }
 
-                        if( e.m_data.is_Data() && e.m_data.as_Data()[idx].is_struct ) {
-                            path.m_bindings.type.set(ap, ::AST::PathBinding_Type::make_EnumVar({nullptr, static_cast<unsigned int>(idx), &e}));
+                        if( e->m_data.is_Data() && e->m_data.as_Data()[idx].is_struct ) {
+                            path.m_bindings.type.set(ap, ::AST::PathBinding_Type::make_EnumVar({nullptr, static_cast<unsigned int>(idx), &*e}));
                         }
                         else {
-                            path.m_bindings.value.set(ap, ::AST::PathBinding_Value::make_EnumVar({nullptr, static_cast<unsigned int>(idx), &e}));
+                            path.m_bindings.value.set(ap, ::AST::PathBinding_Value::make_EnumVar({nullptr, static_cast<unsigned int>(idx), &*e}));
                         }
                         path = split_into_crate(sp, mv$(path), start,  crate.m_name);
                         return;
@@ -1415,35 +1415,35 @@ namespace {
                 if( v != hmod->m_mod_items.end() ) {
 
                     ::AST::PathBinding_Type pbt;
-                    TU_MATCH_HDRA( (v->second->ent), {)
+                    TU_MATCH_HDRA( (v->second.ent), {)
                     TU_ARMA(Import, e) {
                         DEBUG("= Import " << e.path);
                         Resolve_Absolute_Path_BindAbsolute__hir_from_import(context, sp, false,  path, e.path);
                         return ;
                         }
                     TU_ARMA(Trait, e) {
-                        pbt = ::AST::PathBinding_Type::make_Trait({nullptr, &e});
+                        pbt = ::AST::PathBinding_Type::make_Trait({nullptr, &*e});
                         }
                     TU_ARMA(TraitAlias, e) {
-                        pbt = ::AST::PathBinding_Type::make_TraitAlias({nullptr, &e});
+                        pbt = ::AST::PathBinding_Type::make_TraitAlias({nullptr, &*e});
                         }
                     TU_ARMA(Module, e) {
-                        pbt = ::AST::PathBinding_Type::make_Module({nullptr, {&crate, &e}});
+                        pbt = ::AST::PathBinding_Type::make_Module({nullptr, {&crate, &*e}});
                         }
                     TU_ARMA(ExternType, e) {
-                        pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &e*/});
+                        pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &*e*/});
                         }
                     TU_ARMA(TypeAlias, e) {
-                        pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &e*/});
+                        pbt = ::AST::PathBinding_Type::make_TypeAlias({nullptr/*, &*e*/});
                         }
                     TU_ARMA(Enum, e) {
-                        pbt = ::AST::PathBinding_Type::make_Enum({nullptr, &e});
+                        pbt = ::AST::PathBinding_Type::make_Enum({nullptr, &*e});
                         }
                     TU_ARMA(Struct, e) {
-                        pbt = ::AST::PathBinding_Type::make_Struct({nullptr, &e});
+                        pbt = ::AST::PathBinding_Type::make_Struct({nullptr, &*e});
                         }
                     TU_ARMA(Union, e) {
-                        pbt = ::AST::PathBinding_Type::make_Union({nullptr, &e});
+                        pbt = ::AST::PathBinding_Type::make_Union({nullptr, &*e});
                         }
                     }
                     path.m_bindings.type.set(::std::move(ap), ::std::move(pbt));
@@ -1458,9 +1458,9 @@ namespace {
             {
                 auto v = hmod->m_value_items.find(name);
                 if( v != hmod->m_value_items.end() ) {
-                    TU_MATCH_HDRA( (v->second->ent), {)
+                    TU_MATCH_HDRA( (v->second.ent), {)
                     default:
-                        DEBUG("Ignore - " << v->second->ent.tag_str());
+                        DEBUG("Ignore - " << v->second.ent.tag_str());
                     TU_ARMA(StructConstant, e) {
                         auto ty_path = e.ty;
                         path.m_bindings.value.set( ::std::move(ap), ::AST::PathBinding_Value::make_Struct({nullptr, &crate.m_hir->get_struct_by_path(sp, ty_path)}) );
@@ -1490,13 +1490,13 @@ namespace {
                 auto v = hmod->m_value_items.find(name);
                 if( v != hmod->m_value_items.end() ) {
                     ::AST::PathBinding_Value pbv;
-                    TU_MATCH_HDRA( (v->second->ent), {)
+                    TU_MATCH_HDRA( (v->second.ent), {)
                     TU_ARMA(Import, e) {
                         Resolve_Absolute_Path_BindAbsolute__hir_from_import(context, sp, true,  path, e.path);
                         return ;
                         }
                     TU_ARMA(Function, e) {
-                        pbv = ::AST::PathBinding_Value::make_Function({nullptr/*, &e*/});
+                        pbv = ::AST::PathBinding_Value::make_Function({nullptr/*, &*e*/});
                         }
                     TU_ARMA(StructConstructor, e) {
                         auto ty_path = e.ty;
@@ -1507,7 +1507,7 @@ namespace {
                         pbv = ::AST::PathBinding_Value::make_Struct({nullptr, &crate.m_hir->get_struct_by_path(sp, ty_path)});
                         }
                     TU_ARMA(Static, e) {
-                        pbv = ::AST::PathBinding_Value::make_Static({nullptr, &e});
+                        pbv = ::AST::PathBinding_Value::make_Static({nullptr, &*e});
                         }
                     TU_ARMA(Constant, e) {
                         // Bind

--- a/src/resolve/common.cpp
+++ b/src/resolve/common.cpp
@@ -85,9 +85,9 @@ namespace {
                         for(const auto& n : mp.ents)
                         {
                             ASSERT_BUG(sp, mod->m_mod_items.count(n), "Node `" << n << "` missing in path " << mp);
-                            const auto& i = *mod->m_mod_items.at(n);
+                            const auto& i = mod->m_mod_items.at(n);
                             ASSERT_BUG(sp, i.ent.is_Module(), "Node `" << n << "` not a module in path " << mp);
-                            mod = &i.ent.as_Module();
+                            mod = &*i.ent.as_Module();
                         }
                         if(out_path) {
                             out_path->crate = mp.crate;
@@ -174,7 +174,7 @@ namespace {
                         //}
                         //else {
                             ASSERT_BUG(sp, i_ent_ptr->is_Module(), "Expected Module, got " << i_ent_ptr->tag_str() << " for " << name << " in [" << base_nodes << "]");
-                            return get_module_hir(i_ent_ptr->as_Module(), path, 1, ignore_last, out_path);
+                            return get_module_hir(*i_ent_ptr->as_Module(), path, 1, ignore_last, out_path);
                         //}
                         }
                     TU_ARMA(None, e) {
@@ -331,7 +331,7 @@ namespace {
                     }
                 TU_ARMA(Hir, e) {
                     if( const auto* i = e->opt_Module() ) {
-                        return get_module_hir(*i, path, idx+1, ignore_last, out_path);
+                        return get_module_hir(**i, path, idx+1, ignore_last, out_path);
                     }
                     else {
                         DEBUG("Found HIR " << e->tag_str() << ", not module");
@@ -363,11 +363,11 @@ namespace {
                 const auto& name = path.nodes()[i].name();
                 // Find the module for this node
                 auto it = mod->m_mod_items.find(name);
-                if( it == mod->m_mod_items.end() || !it->second->publicity.is_global() ) {
+                if( it == mod->m_mod_items.end() || !it->second.publicity.is_global() ) {
                     DEBUG(name << " Not Found");
                     return ResolveModuleRef();
                 }
-                const auto* ti = &it->second->ent;
+                const auto* ti = &it->second.ent;
                 if(const auto* imp = ti->opt_Import())
                 {
                     ASSERT_BUG(sp, crate.m_extern_crates.count(imp->path.crate_name()), "Crate " << imp->path.crate_name() << " not loaded");
@@ -391,7 +391,7 @@ namespace {
                     DEBUG(name << " Not Module, instead " << ti->tag_str());
                     return ResolveModuleRef();
                 TU_ARMA(Module, m) {
-                    mod = &m;
+                    mod = &*m;
                     }
                 }
             }
@@ -761,7 +761,7 @@ namespace {
                 }
                 static const HIR::Module& get_mod_for_hir_path(const Span& sp, const AST::Crate& crate, const HIR::SimplePath& p) {
                     const auto& hir_crate = *crate.m_extern_crates.at(p.crate_name()).m_hir;
-                    return hir_crate.get_mod_by_path(sp, p, /*ignore_last*/true, /*ingore_crate*/true);
+                    return hir_crate.get_mod_by_path(sp, p, /*ignore_last*/true, /*ignore_crate*/true);
                 }
             };
 
@@ -770,10 +770,10 @@ namespace {
             {
             case ResolveNamespace::Namespace: {
                 auto it = mod.m_mod_items.find(item_name);
-                if( it != mod.m_mod_items.end() && it->second->publicity.is_visible(vis_path) ) {
+                if( it != mod.m_mod_items.end() && it->second.publicity.is_visible(vis_path) ) {
                     DEBUG("Found `" << item_name << "` in HIR namespace");
                     const HIR::TypeItem*    ti;
-                    if(const auto* p = it->second->ent.opt_Import()) {
+                    if(const auto* p = it->second.ent.opt_Import()) {
                         if(out_path) {
                             *out_path = sp_to_ap(p->path);
                         }
@@ -786,18 +786,18 @@ namespace {
                     else {
                         if(out_path)
                             out_path->nodes.push_back(item_name);
-                        ti = &it->second->ent;
+                        ti = &it->second.ent;
                     }
-                    ASSERT_BUG(sp, !ti->is_Import(), "Recursive namespace import in HIR: " << it->second->ent.as_Import().path << " pointed to " << ti->as_Import().path);
+                    ASSERT_BUG(sp, !ti->is_Import(), "Recursive namespace import in HIR: " << it->second.ent.as_Import().path << " pointed to " << ti->as_Import().path);
                     return ResolveItemRef_Type(ti);
                 }
                 } break;
             case ResolveNamespace::Value: {
                 auto it = mod.m_value_items.find(item_name);
-                if( it != mod.m_value_items.end() && it->second->publicity.is_visible(vis_path) ) {
+                if( it != mod.m_value_items.end() && it->second.publicity.is_visible(vis_path) ) {
                     DEBUG("Found `" << item_name << "` in HIR value");
                     const HIR::ValueItem*    vi;
-                    if(const auto* p = it->second->ent.opt_Import()) {
+                    if(const auto* p = it->second.ent.opt_Import()) {
                         if(out_path) {
                             *out_path = sp_to_ap(p->path);
                         }
@@ -806,9 +806,9 @@ namespace {
                     else {
                         if(out_path)
                             out_path->nodes.push_back(item_name);
-                        vi = &it->second->ent;
+                        vi = &it->second.ent;
                     }
-                    ASSERT_BUG(sp, !vi->is_Import(), "Recursive value import in HIR: " << it->second->ent.as_Import().path << " pointed to " << vi->as_Import().path);
+                    ASSERT_BUG(sp, !vi->is_Import(), "Recursive value import in HIR: " << it->second.ent.as_Import().path << " pointed to " << vi->as_Import().path);
                     return ResolveItemRef_Value(vi);
                 }
                 } break;
@@ -817,13 +817,13 @@ namespace {
                 if( it == mod.m_macro_items.end() ) {
                     DEBUG("Did not find `" << item_name << "` in HIR macro");
                 }
-                else if( !it->second->publicity.is_visible(vis_path) ) {
+                else if( !it->second.publicity.is_visible(vis_path) ) {
                     DEBUG("Found `" << item_name << "` in HIR macro - but not public, ignoring");
                 }
                 else {
                     DEBUG("Found `" << item_name << "` in HIR macro");
                     const HIR::MacroItem* mi;
-                    if(const auto* p = it->second->ent.opt_Import()) {
+                    if(const auto* p = it->second.ent.opt_Import()) {
                         if(out_path) {
                             *out_path = sp_to_ap(p->path);
                         }
@@ -858,24 +858,24 @@ namespace {
                                 }
                                 return v;
                             }
-                            // Fall throught to fail
+                            // Fall through to fail
                         }
                     }
                     else {
-                        mi = &it->second->ent;
+                        mi = &it->second.ent;
                         if(out_path) {
                             out_path->nodes.push_back(item_name);
                         }
                     }
                     TU_MATCH_HDRA( (*mi), {)
                     TU_ARMA(Import, me) {
-                        BUG(sp, "Recursive macro import in HIR: " << it->second->ent.as_Import().path << " pointed to " << me.path);
+                        BUG(sp, "Recursive macro import in HIR: " << it->second.ent.as_Import().path << " pointed to " << me.path);
                         }
                     TU_ARMA(MacroRules, me) {
                         return ResolveItemRef_Macro(&*me);
                         }
                     TU_ARMA(ProcMacro, me) {
-                        return ResolveItemRef_Macro(&me);
+                        return ResolveItemRef_Macro(&*me);
                         }
                     }
                 }

--- a/src/resolve/index.cpp
+++ b/src/resolve/index.cpp
@@ -239,7 +239,7 @@ void Resolve_Index_Module_Base(const AST::Crate& crate, AST::Module& mod)
             ASSERT_BUG(sp, i_data.path.m_bindings.has_binding(), "`use " << i_data.path << "` left unbound in module " << mod.path());
             const auto& pb = i_data.path.m_bindings;
 
-            bool allow_collide = true;  // Allow collisions (`use` can import mutliple namespaces, local gets priority)
+            bool allow_collide = true;  // Allow collisions (`use` can import multiple namespaces, local gets priority)
             // - Types
             TU_MATCH_HDRA( (pb.type.binding), {)
             TU_ARMA(Unbound, _e) {
@@ -341,7 +341,7 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
 {
     TRACE_FUNCTION_F(dst_mod.path() << " <= " << mod_ap);
     for(const auto& it : hmod.m_mod_items) {
-        const auto& ve = *it.second;
+        const auto& ve = it.second;
         if( ve.publicity.is_global() ) {
             const auto* vep = &ve.ent;
 
@@ -362,18 +362,18 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
                 for(unsigned int i = 0; i < spath.components().size()-1; i ++) {
                     const auto& hit = hmod->m_mod_items.at( spath.components()[i] );
                     // Only support enums on the penultimate component
-                    if( i == spath.components().size()-2 && hit->ent.is_Enum() ) {
+                    if( i == spath.components().size()-2 && hit.ent.is_Enum() ) {
                         pb.binding = ::AST::PathBinding_Type::make_EnumVar({nullptr, 0});
                         _add_item_type( sp, dst_mod, it.first, vis, mv$(pb), false );
                         hmod = nullptr;
                         break ;
                     }
-                    ASSERT_BUG(sp, hit->ent.is_Module(), "Path component " << spath.components()[i] << " of " << spath << " is not a module, instead " << hit->ent.tag_str());
-                    hmod = &hit->ent.as_Module();
+                    ASSERT_BUG(sp, hit.ent.is_Module(), "Path component " << spath.components()[i] << " of " << spath << " is not a module, instead " << hit.ent.tag_str());
+                    hmod = &*hit.ent.as_Module();
                 }
                 if( !hmod )
                     continue ;
-                vep = &hmod->m_mod_items.at( spath.components().back() )->ent;
+                vep = &hmod->m_mod_items.at( spath.components().back() ).ent;
             }
             else {
                 pb.path = mod_ap + it.first;
@@ -384,19 +384,19 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
                 TODO(sp, "Get binding for HIR import? " << e.path);
                 }
             TU_ARMA(Module, e) {
-                pb.binding = ::AST::PathBinding_Type::make_Module({nullptr, {nullptr, &e}});
+                pb.binding = ::AST::PathBinding_Type::make_Module({nullptr, {nullptr, &*e}});
                 }
             TU_ARMA(Trait, e) {
-                pb.binding = ::AST::PathBinding_Type::make_Trait({nullptr, &e});
+                pb.binding = ::AST::PathBinding_Type::make_Trait({nullptr, &*e});
                 }
             TU_ARMA(Struct, e) {
-                pb.binding = ::AST::PathBinding_Type::make_Struct({nullptr, &e});
+                pb.binding = ::AST::PathBinding_Type::make_Struct({nullptr, &*e});
                 }
             TU_ARMA(TraitAlias, e) {
-                pb.binding = ::AST::PathBinding_Type::make_TraitAlias({nullptr, &e});
+                pb.binding = ::AST::PathBinding_Type::make_TraitAlias({nullptr, &*e});
                 }
             TU_ARMA(Union, e) {
-                pb.binding = ::AST::PathBinding_Type::make_Union({nullptr, &e});
+                pb.binding = ::AST::PathBinding_Type::make_Union({nullptr, &*e});
                 }
             TU_ARMA(Enum, e) {
                 pb.binding = ::AST::PathBinding_Type::make_Enum({nullptr});
@@ -412,7 +412,7 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
         }
     }
     for(const auto& it : hmod.m_value_items) {
-        const auto& ve = *it.second;
+        const auto& ve = it.second;
         if( ve.publicity.is_global() ) {
             const auto* vep = &ve.ent;
 
@@ -426,20 +426,20 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
                 const auto* hmod = &crate.m_extern_crates.at(spath.crate_name()).m_hir->m_root_module;
                 for(unsigned int i = 0; i < spath.components().size()-1; i ++) {
                     const auto& hit = hmod->m_mod_items.at( spath.components()[i] );
-                    if( i == spath.components().size()-2 && hit->ent.is_Enum() ) {
-                        auto idx = hit->ent.as_Enum().find_variant(spath.components().back());
+                    if( i == spath.components().size()-2 && hit.ent.is_Enum() ) {
+                        auto idx = hit.ent.as_Enum()->find_variant(spath.components().back());
                         ASSERT_BUG(sp, idx != SIZE_MAX, spath);
                         pb.binding = ::AST::PathBinding_Value::make_EnumVar({nullptr, static_cast<unsigned>(idx)});
                         _add_item_value( sp, dst_mod, it.first, vis, mv$(pb), false );
                         hmod = nullptr;
                         break ;
                     }
-                    ASSERT_BUG(sp, hit->ent.is_Module(), "Path component " << spath.components()[i] << " of " << spath << " is not a module, instead " << hit->ent.tag_str());
-                    hmod = &hit->ent.as_Module();
+                    ASSERT_BUG(sp, hit.ent.is_Module(), "Path component " << spath.components()[i] << " of " << spath << " is not a module, instead " << hit.ent.tag_str());
+                    hmod = &*hit.ent.as_Module();
                 }
                 if( !hmod )
                     continue ;
-                vep = &hmod->m_value_items.at( spath.components().back() )->ent;
+                vep = &hmod->m_value_items.at( spath.components().back() ).ent;
             }
             else {
                 pb.path = mod_ap + it.first;
@@ -457,10 +457,10 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
                 }
             // TODO: What if these refer to an enum variant?
             TU_ARMA(StructConstant, e) {
-                pb.binding = ::AST::PathBinding_Value::make_Struct({ nullptr, &crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct() });
+                pb.binding = ::AST::PathBinding_Value::make_Struct({ nullptr, &*crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct() });
                 }
             TU_ARMA(StructConstructor, e) {
-                pb.binding = ::AST::PathBinding_Value::make_Struct({ nullptr, &crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct() });
+                pb.binding = ::AST::PathBinding_Value::make_Struct({ nullptr, &*crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(sp, e.ty, true).as_Struct() });
                 }
             TU_ARMA(Function, e) {
                 pb.binding = ::AST::PathBinding_Value::make_Function({nullptr});
@@ -470,7 +470,7 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
         }
     }
     for(const auto& it : hmod.m_macro_items) {
-        const auto& e = *it.second;
+        const auto& e = it.second;
         if( e.publicity.is_global() ) {
             ::AST::PathBinding<::AST::PathBinding_Macro>    pb;
             if(const auto* ep = e.ent.opt_Import()) {
@@ -487,7 +487,7 @@ void Resolve_Index_Module_Wildcard__glob_in_hir_mod(
                 pb.binding = ::AST::PathBinding_Macro::make_MacroRules({ nullptr, nullptr });
                 }
             TU_ARMA(ProcMacro, me) {
-                pb.binding = ::AST::PathBinding_Macro::make_ProcMacro({ nullptr, me.name });
+                pb.binding = ::AST::PathBinding_Macro::make_ProcMacro({ nullptr, me->name });
                 }
             TU_ARMA(MacroRules, me) {
                 pb.binding = ::AST::PathBinding_Macro::make_MacroRules({ nullptr, &*me });
@@ -713,7 +713,7 @@ void Resolve_Index_Module_Normalise_Path_ext(const ::AST::Crate& crate, const Sp
         if( it == hmod->m_mod_items.end() ) {
             ERROR(sp, E0000,  "Couldn't find node " << i << " of path " << path);
         }
-        const auto* item_ptr = &it->second->ent;
+        const auto* item_ptr = &it->second.ent;
         if( item_ptr->is_Import() ) {
             const auto& e = item_ptr->as_Import();
             const auto& ec = crate.m_extern_crates.at( e.path.crate_name() );
@@ -731,7 +731,7 @@ void Resolve_Index_Module_Normalise_Path_ext(const ::AST::Crate& crate, const Sp
             BUG(sp, "Path " << path << " pointed to non-module in component " << i);
             ),
         (Import,
-            BUG(sp, "Recursive import in " << path << " - " << it->second->ent.as_Import().path << " -> " << e.path);
+            BUG(sp, "Recursive import in " << path << " - " << it->second.ent.as_Import().path << " -> " << e.path);
             ),
         (Enum,
             if( i != info.nodes.size() - 2 ) {
@@ -741,7 +741,7 @@ void Resolve_Index_Module_Normalise_Path_ext(const ::AST::Crate& crate, const Sp
             return ;
             ),
         (Module,
-            hmod = &e;
+            hmod = &*e;
             )
         )
     }
@@ -754,12 +754,12 @@ void Resolve_Index_Module_Normalise_Path_ext(const ::AST::Crate& crate, const Sp
         auto it_m = hmod->m_mod_items.find( lastnode.name() );
         if( it_m != hmod->m_mod_items.end() )
         {
-            TU_IFLET( ::HIR::TypeItem, it_m->second->ent, Import, e,
+            if( const auto* e = it_m->second.ent.opt_Import() ) {
                 // Replace the path with this path (maintaining binding)
                 auto bindings = path.m_bindings.clone();
-                path = hir_to_ast(e.path);
+                path = hir_to_ast(e->path);
                 path.m_bindings = mv$(bindings);
-            )
+            }
             return ;
         }
         } break;
@@ -767,12 +767,12 @@ void Resolve_Index_Module_Normalise_Path_ext(const ::AST::Crate& crate, const Sp
         auto it_v = hmod->m_value_items.find( lastnode.name() );
         if( it_v != hmod->m_value_items.end() )
         {
-            TU_IFLET( ::HIR::ValueItem, it_v->second->ent, Import, e,
+            if( const auto* e = it_v->second.ent.opt_Import() ) {
                 // Replace the path with this path (maintaining binding)
                 auto bindings = path.m_bindings.clone();
-                path = hir_to_ast(e.path);
+                path = hir_to_ast(e->path);
                 path.m_bindings = mv$(bindings);
-            )
+            }
             return ;
         }
         } break;
@@ -780,8 +780,7 @@ void Resolve_Index_Module_Normalise_Path_ext(const ::AST::Crate& crate, const Sp
         auto it_v = hmod->m_macro_items.find( lastnode.name() );
         if( it_v != hmod->m_macro_items.end() )
         {
-            if(const auto* e = it_v->second->ent.opt_Import())
-            {
+            if( const auto* e = it_v->second.ent.opt_Import() ) {
                 // Replace the path with this path (maintaining binding)
                 auto bindings = path.m_bindings.clone();
                 path = hir_to_ast(e->path);

--- a/src/resolve/use.cpp
+++ b/src/resolve/use.cpp
@@ -749,15 +749,15 @@ namespace {
             auto it = hmod->m_mod_items.find(node);
             if( it == hmod->m_mod_items.end() )
                 BUG(sp, "");
-            TU_IFLET( ::HIR::TypeItem, (it->second->ent), Module, mod,
-                hmod = &mod;
+            TU_IFLET( ::HIR::TypeItem, (it->second.ent), Module, mod,
+                hmod = &*mod;
             )
-            else TU_IFLET( ::HIR::TypeItem, (it->second->ent), Import, import,
+            else TU_IFLET( ::HIR::TypeItem, (it->second.ent), Import, import,
                 hmod = get_hir_mod_by_path(sp, crate, import.path);
                 if( !hmod )
                     BUG(sp, "Import in module position didn't resolve as a module - " << import.path);
             )
-            else TU_IFLET( ::HIR::TypeItem, (it->second->ent), Enum, enm,
+            else TU_IFLET( ::HIR::TypeItem, (it->second.ent), Enum, enm,
                 if( &node == &path.components().back() ) {
                     is_enum = true;
                     return &enm;
@@ -815,10 +815,10 @@ namespace {
             // BZZT!
             ERROR(span, E0000, "Unable to find path component " << nodes[i].name() << " in " << path << " (" << ap << ")");
         }
-        DEBUG(i << " : " << nodes[i].name() << " = " << it->second->ent.tag_str());
-        TU_MATCH_HDRA( (it->second->ent), {)
+        DEBUG(i << " : " << nodes[i].name() << " = " << it->second.ent.tag_str());
+        TU_MATCH_HDRA( (it->second.ent), {)
         default:
-            ERROR(span, E0000, "Unexpected item type in import " << path << " @ " << i << " - " << it->second->ent.tag_str());
+            ERROR(span, E0000, "Unexpected item type in import " << path << " @ " << i << " - " << it->second.ent.tag_str());
         TU_ARMA(Import, e) {
             // TODO: This is kinda like a duplicate of Resolve_Absolute_Path_BindAbsolute__hir_from ?
             bool is_enum = false;
@@ -855,7 +855,7 @@ namespace {
             }
             }
         TU_ARMA(Module, e) {
-            hmod = &e;
+            hmod = &*e;
             }
         TU_ARMA(Enum, e) {
             i += 1;
@@ -865,15 +865,15 @@ namespace {
             const auto& name = nodes[i].name();
             ap.nodes.push_back(name);
 
-            auto idx = e.find_variant(name);
+            auto idx = e->find_variant(name);
             if(idx == SIZE_MAX) {
                 ERROR(span, E0000, "Unable to find variant " << path);
             }
-            if( e.m_data.is_Data() && e.m_data.as_Data()[idx].is_struct ) {
-                rv.type.set(ap, ::AST::PathBinding_Type::make_EnumVar({ nullptr, static_cast<unsigned int>(idx), &e }) );
+            if( e->m_data.is_Data() && e->m_data.as_Data()[idx].is_struct ) {
+                rv.type.set(ap, ::AST::PathBinding_Type::make_EnumVar({ nullptr, static_cast<unsigned int>(idx), &*e }) );
             }
             else {
-                rv.value.set(ap, ::AST::PathBinding_Value::make_EnumVar({ nullptr, static_cast<unsigned int>(idx), &e }) );
+                rv.value.set(ap, ::AST::PathBinding_Value::make_EnumVar({ nullptr, static_cast<unsigned int>(idx), &*e }) );
             }
             return rv;
             }
@@ -887,15 +887,15 @@ namespace {
         auto it = hmod->m_mod_items.find(nodes.back().name());
         if( it == hmod->m_mod_items.end() )
         {
-            DEBUG("E: : Types = " << FMT_CB(ss, for(const auto& e : hmod->m_mod_items){ ss << e.first << ":" << e.second->ent.tag_str() << ","; }));
+            DEBUG("E: : Types = " << FMT_CB(ss, for(const auto& e : hmod->m_mod_items){ ss << e.first << ":" << e.second.ent.tag_str() << ","; }));
         }
-        else if( !it->second->publicity.is_global() )
+        else if( !it->second.publicity.is_global() )
         {
-            DEBUG("E : Mod " << nodes.back().name() << " = " << it->second->ent.tag_str() << " [private]");
+            DEBUG("E : Mod " << nodes.back().name() << " = " << it->second.ent.tag_str() << " [private]");
         }
         else
         {
-            const auto* item_ptr = &it->second->ent;
+            const auto* item_ptr = &it->second.ent;
             auto ap2 = ap; auto ap = ap2;
             DEBUG("E : Mod " << nodes.back().name() << " = " << item_ptr->tag_str());
             if( item_ptr->is_Import() ) {
@@ -911,8 +911,8 @@ namespace {
                     // This doesn't need to recurse - it can just do a single layer (as no Import should refer to another)
                     if( e.is_variant ) {
                         const auto& enm = ec.m_hir->get_typeitem_by_path(span, e.path, /*ignore_crate_name*/true, /*ignore_last_node*/true).as_Enum();
-                        assert(e.idx < enm.num_variants());
-                        rv.type.set( ap, ::AST::PathBinding_Type::make_EnumVar({ nullptr, e.idx, &enm }) );
+                        assert(e.idx < enm->num_variants());
+                        rv.type.set( ap, ::AST::PathBinding_Type::make_EnumVar({ nullptr, e.idx, &*enm }) );
                     }
                     else if( e.path.components().empty() ) {
                         rv.type.set( ap, ::AST::PathBinding_Type::make_Module({nullptr, {&ec, &ec.m_hir->m_root_module}}) );
@@ -928,10 +928,10 @@ namespace {
             {
                 TU_MATCHA( (*item_ptr), (e),
                 (Import,
-                    BUG(span, "Recursive import in " << path << " - " << it->second->ent.as_Import().path << " -> " << e.path);
+                    BUG(span, "Recursive import in " << path << " - " << it->second.ent.as_Import().path << " -> " << e.path);
                     ),
                 (Module,
-                    rv.type.set( ap, ::AST::PathBinding_Type::make_Module({nullptr, {&hcrate, &e}}) );
+                    rv.type.set( ap, ::AST::PathBinding_Type::make_Module({nullptr, {&hcrate, &*e}}) );
                     ),
                 (TypeAlias,
                     rv.type.set( ap, ::AST::PathBinding_Type::make_TypeAlias({nullptr}) );
@@ -940,19 +940,19 @@ namespace {
                     rv.type.set( ap, ::AST::PathBinding_Type::make_TypeAlias({nullptr}) );   // Lazy.
                     ),
                 (Enum,
-                    rv.type.set( ap, ::AST::PathBinding_Type::make_Enum({nullptr, &e}) );
+                    rv.type.set( ap, ::AST::PathBinding_Type::make_Enum({nullptr, &*e}) );
                     ),
                 (Struct,
-                    rv.type.set( ap, ::AST::PathBinding_Type::make_Struct({nullptr, &e}) );
+                    rv.type.set( ap, ::AST::PathBinding_Type::make_Struct({nullptr, &*e}) );
                     ),
                 (Union,
-                    rv.type.set( ap, ::AST::PathBinding_Type::make_Union({nullptr, &e}) );
+                    rv.type.set( ap, ::AST::PathBinding_Type::make_Union({nullptr, &*e}) );
                     ),
                 (Trait,
-                    rv.type.set( ap, ::AST::PathBinding_Type::make_Trait({nullptr, &e}) );
+                    rv.type.set( ap, ::AST::PathBinding_Type::make_Trait({nullptr, &*e}) );
                     ),
                 (TraitAlias,
-                    rv.type.set( ap, ::AST::PathBinding_Type::make_TraitAlias({nullptr, &e}) );
+                    rv.type.set( ap, ::AST::PathBinding_Type::make_TraitAlias({nullptr, &*e}) );
                     )
                 )
             }
@@ -963,15 +963,15 @@ namespace {
         auto it = hmod->m_value_items.find(nodes.back().name());
         if( it ==  hmod->m_value_items.end() )
         {
-            DEBUG("E : Values = " << FMT_CB(ss, for(const auto& e : hmod->m_value_items){ ss << e.first << ":" << e.second->ent.tag_str() << ","; }));
+            DEBUG("E : Values = " << FMT_CB(ss, for(const auto& e : hmod->m_value_items){ ss << e.first << ":" << e.second.ent.tag_str() << ","; }));
         }
-        else if( !it->second->publicity.is_global() )
+        else if( !it->second.publicity.is_global() )
         {
-            DEBUG("E : Value " << nodes.back().name() << " = " << it->second->ent.tag_str() << " [private]");
+            DEBUG("E : Value " << nodes.back().name() << " = " << it->second.ent.tag_str() << " [private]");
         }
         else
         {
-            const auto* item_ptr = &it->second->ent;
+            const auto* item_ptr = &it->second.ent;
             auto ap2 = ap; auto ap = ap2;
             DEBUG("E : Value " << nodes.back().name() << " = " << item_ptr->tag_str());
             if( item_ptr->is_Import() ) {
@@ -984,8 +984,8 @@ namespace {
                     auto p = e.path;
                     p.pop_component();
                     const auto& enm = ec.m_hir->get_typeitem_by_path(span, p, true).as_Enum();
-                    assert(e.idx < enm.num_variants());
-                    rv.value.set( ap, ::AST::PathBinding_Value::make_EnumVar({ nullptr, e.idx, &enm }) );
+                    assert(e.idx < enm->num_variants());
+                    rv.value.set( ap, ::AST::PathBinding_Value::make_EnumVar({ nullptr, e.idx, &*enm }) );
                 }
                 else
                 {
@@ -996,7 +996,7 @@ namespace {
             {
                 TU_MATCH_HDRA( (*item_ptr), {)
                 TU_ARMA(Import, e) {
-                    BUG(span, "Recursive import in " << path << " - " << it->second->ent.as_Import().path << " -> " << e.path);
+                    BUG(span, "Recursive import in " << path << " - " << it->second.ent.as_Import().path << " -> " << e.path);
                     }
                 TU_ARMA(Constant, e) {
                     rv.value.set( ap, ::AST::PathBinding_Value::make_Static({ nullptr }) );
@@ -1007,11 +1007,11 @@ namespace {
                 // TODO: What happens if these two refer to an enum constructor?
                 TU_ARMA(StructConstant, e) {
                     ASSERT_BUG(span, crate.m_extern_crates.count(e.ty.crate_name()), "Crate '" << e.ty.crate_name() << "' not loaded for " << e.ty);
-                    rv.value.set( ap, ::AST::PathBinding_Value::make_Struct({ nullptr, &crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(span, e.ty, true).as_Struct() }) );
+                    rv.value.set( ap, ::AST::PathBinding_Value::make_Struct({ nullptr, &*crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(span, e.ty, true).as_Struct() }) );
                     }
                 TU_ARMA(StructConstructor, e) {
                     ASSERT_BUG(span, crate.m_extern_crates.count(e.ty.crate_name()), "Crate '" << e.ty.crate_name() << "' not loaded for " << e.ty);
-                    rv.value.set( ap, ::AST::PathBinding_Value::make_Struct({ nullptr, &crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(span, e.ty, true).as_Struct() }) );
+                    rv.value.set( ap, ::AST::PathBinding_Value::make_Struct({ nullptr, &*crate.m_extern_crates.at(e.ty.crate_name()).m_hir->get_typeitem_by_path(span, e.ty, true).as_Struct() }) );
                     }
                 TU_ARMA(Function, e) {
                     rv.value.set( ap, ::AST::PathBinding_Value::make_Function({ nullptr }) );
@@ -1025,15 +1025,15 @@ namespace {
         auto it = hmod->m_macro_items.find(nodes.back().name());
         if( it == hmod->m_macro_items.end() )
         {
-            DEBUG("E : Macros = " << FMT_CB(ss, for(const auto& e : hmod->m_macro_items){ ss << e.first << ":" << e.second->ent.tag_str() << ","; }));
+            DEBUG("E : Macros = " << FMT_CB(ss, for(const auto& e : hmod->m_macro_items){ ss << e.first << ":" << e.second.ent.tag_str() << ","; }));
         }
-        else if( !it->second->publicity.is_global() )
+        else if( !it->second.publicity.is_global() )
         {
-            DEBUG("E : Macro " << nodes.back().name() << " = " << it->second->ent.tag_str() << " [private]");
+            DEBUG("E : Macro " << nodes.back().name() << " = " << it->second.ent.tag_str() << " [private]");
         }
         else
         {
-            const auto* item_ptr = &it->second->ent;
+            const auto* item_ptr = &it->second.ent;
             auto ap2 = ap; auto ap = ap2;
             DEBUG("E : Macro " << nodes.back().name() << " = " << item_ptr->tag_str());
 
@@ -1046,7 +1046,7 @@ namespace {
                 ASSERT_BUG(span, crate.m_extern_crates.count(imp->path.crate_name()) > 0, "Unable to find crate for " << imp->path);
                 const auto& c = *crate.m_extern_crates.at(imp->path.crate_name()).m_hir;    // Have to manually look up, AST doesn't have a `get_mod_by_path`
                 const auto& mod = c.get_mod_by_path(span, imp->path, /*ignore_last=*/true, /*ignore_crate=*/true);
-                item_ptr = &mod.m_macro_items.at(imp->path.components().back())->ent;
+                item_ptr = &mod.m_macro_items.at(imp->path.components().back()).ent;
                 ap = AST::AbsolutePath(imp->path.crate_name(), imp->path.components().to_vec());
             }
             else {
@@ -1059,11 +1059,11 @@ namespace {
                     if( e.path.crate_name() == rcstring_crate_builtins )
                         ;
                     else
-                        BUG(span, "Recursive import in " << path << " - " << it->second->ent.as_Import().path << " -> " << e.path);
+                        BUG(span, "Recursive import in " << path << " - " << it->second.ent.as_Import().path << " -> " << e.path);
                     rv.macro.set( ap, ::AST::PathBinding_Macro::make_MacroRules({ nullptr, nullptr }) );
                     }
                 TU_ARMA(ProcMacro, e) {
-                    rv.macro.set( ap, ::AST::PathBinding_Macro::make_ProcMacro({ &hcrate, e.name }) );
+                    rv.macro.set( ap, ::AST::PathBinding_Macro::make_ProcMacro({ &hcrate, e->name }) );
                     }
                 TU_ARMA(MacroRules, e) {
                     rv.macro.set( ap, ::AST::PathBinding_Macro::make_MacroRules({ nullptr, &*e } ) );

--- a/src/resolve/use.cpp
+++ b/src/resolve/use.cpp
@@ -760,7 +760,8 @@ namespace {
             else TU_IFLET( ::HIR::TypeItem, (it->second.ent), Enum, enm,
                 if( &node == &path.components().back() ) {
                     is_enum = true;
-                    return &enm;
+                    const ::HIR::Enum* enm_p = &*enm;
+                    return enm_p;
                 }
                 BUG(sp, "");
             )

--- a/src/trans/codegen.cpp
+++ b/src/trans/codegen.cpp
@@ -85,11 +85,11 @@ void Trans_Codegen(const ::std::string& outfile, CodegenOutput out_ty, const Tra
             const auto& nse = crate_ptr->get_typeitem_by_path(sp, path.m_path, false, true);
             if(const auto* e = nse.opt_Enum())
             {
-                auto var_idx = e->find_variant(path.m_path.components().back());
-                codegen->emit_constructor_enum(sp, path, *e, var_idx);
+                auto var_idx = (*e)->find_variant(path.m_path.components().back());
+                codegen->emit_constructor_enum(sp, path, **e, var_idx);
                 continue ;
             }
-            mod_ptr = &nse.as_Module();
+            mod_ptr = &*nse.as_Module();
         }
         else
         {
@@ -97,8 +97,8 @@ void Trans_Codegen(const ::std::string& outfile, CodegenOutput out_ty, const Tra
         }
 
         // Not an enum, currently must be a struct
-        const auto& te = mod_ptr->m_mod_items.at(path.m_path.components().back())->ent;
-        codegen->emit_constructor_struct(sp, path, te.as_Struct());
+        const auto& te = mod_ptr->m_mod_items.at(path.m_path.components().back()).ent;
+        codegen->emit_constructor_struct(sp, path, *te.as_Struct());
     }
     list.m_constructors.clear();
 

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -4145,7 +4145,7 @@ namespace {
                 TU_ARMA(EnumVariant, ve) {
                     const auto& tyi = m_crate.get_typeitem_by_path(sp, ve.path.m_path);
                     MIR_ASSERT(mir_res, tyi.is_Enum(), "");
-                    const auto* enm_p = &tyi.as_Enum();
+                    const auto* enm_p = &*tyi.as_Enum();
 
                     ::HIR::TypeRef  tmp;
                     const auto& ty = mir_res.get_lvalue_type(tmp, e.dst);

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -2661,6 +2661,10 @@ namespace {
         {
             print_escaped_string_inner(s.c_str(), s.c_str() + s.size());
         }
+        void print_escaped_string(const RcString& s)
+        {
+            print_escaped_string_inner(s.c_str(), s.c_str() + s.size());
+        }
         void print_escaped_string(const std::vector<uint8_t>& s)
         {
             const char* start =  reinterpret_cast<const char*>(s.data());

--- a/src/trans/codegen_mmir.cpp
+++ b/src/trans/codegen_mmir.cpp
@@ -1036,7 +1036,7 @@ namespace
                     TU_ARM(e.values, String, ve)
                         for(size_t i = 0; i < ve.size(); i++)
                         {
-                            m_of << "\"" << FmtEscaped(ve[i]) << "\" = " << e.targets[i] << ",";
+                            m_of << "\"" << FmtEscaped(ve[i].c_str(), ve[i].size()) << "\" = " << e.targets[i] << ",";
                         }
                         break;
                     TU_ARM(e.values, ByteString, ve) {

--- a/src/trans/enumerate.cpp
+++ b/src/trans/enumerate.cpp
@@ -76,9 +76,9 @@ namespace {
         {
             for(const auto& vi : mod.m_value_items)
             {
-                if( const auto* ip = vi.second->ent.opt_Function() )
+                if( const auto* ip = vi.second.ent.opt_Function() )
                 {
-                    const auto& i = *ip;
+                    const auto& i = **ip;
                     if( i.m_code.m_mir && i.m_linkage.name != "" )
                     {
                         m_link_functions[i.m_linkage.name] = std::make_pair( (mod_path + vi.first).get_simple_path(), &i );
@@ -88,9 +88,9 @@ namespace {
 
             for(const auto& ti : mod.m_mod_items)
             {
-                if( const auto* ip = ti.second->ent.opt_Module() )
+                if( const auto* ip = ti.second.ent.opt_Module() )
                 {
-                    enumerate_link_functions_in(*ip, mod_path + ti.first);
+                    enumerate_link_functions_in(**ip, mod_path + ti.first);
                 }
             }
         }
@@ -261,36 +261,37 @@ namespace {
             if( is_visible ) {
                 // Visible constants need their relocations added as roots
                 // - Can't add this logic to `Trans_Enumerate_FillFrom_Literal` as it's used by non-public enumeration
-                for(const auto& r : e.m_value_res.relocations) {
+                for(const auto& r : e->m_value_res.relocations) {
                     if( r.p ) {
                         state.rv.m_roots.push_back(r.p->clone());
                     }
                 }
-                Trans_Enumerate_FillFrom_Literal(state, e.m_value_res, Trans_Params());
+                Trans_Enumerate_FillFrom_Literal(state, e->m_value_res, Trans_Params());
             }
             } break;
         TU_ARM(vi, Static, e) {
-            if( e.m_linkage.name != "" || e.m_linkage.section != "" )
+            if( e->m_linkage.name != "" || e->m_linkage.section != "" )
             {
                 // If a link name is set, force emit
                 is_visible = true;
             }
-            if( is_visible && !e.m_params.is_generic() )
+            if( is_visible && !e->m_params.is_generic() )
             {
                 // HACK: Refuse to emit unused generated statics
                 // - Needed because all items are visited (regardless of
                 // visibility)
-                if(e.m_type.data().is_Infer())
+                if(e->m_type.data().is_Infer())
                     continue ;
                 //state.enum_static(mod_path + vi.first, *e);
                 auto* ptr = state.rv.add_static( get_path() );
                 if(ptr)
-                    Trans_Enumerate_FillFrom_Static(state, e, *ptr);
+                    Trans_Enumerate_FillFrom_Static(state, *e, *ptr);
 
                 state.rv.m_roots.push_back(get_path());
             }
             } break;
-        TU_ARM(vi, Function, e) {
+        TU_ARM(vi, Function, ep) {
+            const auto& e = *ep;
             bool is_inline = false;
             if(is_visible)
             {
@@ -342,26 +343,26 @@ namespace {
         TRACE_FUNCTION_F(mod_path);
         for(auto& vi : mod.m_value_items)
         {
-            bool emit = is_visible && vi.second->publicity.is_global();
+            bool emit = is_visible && vi.second.publicity.is_global();
             auto p = mod_path + vi.first;
             if( ::std::any_of(state.crate.m_lang_items.begin(), state.crate.m_lang_items.end(), [&](const auto& e){ return e.second == p; }) ) {
                 emit = true;
             }
-            Trans_Enumerate_ValItem(state, vi.second->ent, emit, [&](){ return p; });
+            Trans_Enumerate_ValItem(state, vi.second.ent, emit, [&](){ return p; });
         }
 
         for(auto& ti : mod.m_mod_items)
         {
-            if(auto* e = ti.second->ent.opt_Module() )
+            if(auto* e = ti.second.ent.opt_Module() )
             {
-                Trans_Enumerate_Public_Mod(state, *e, mod_path + ti.first, ti.second->publicity.is_global());
+                Trans_Enumerate_Public_Mod(state, **e, mod_path + ti.first, ti.second.publicity.is_global());
             }
-            else if( const HIR::Trait* e = ti.second->ent.opt_Trait() )
+            else if( const auto* e = ti.second.ent.opt_Trait() )
             {
-                auto params = e->m_params.make_empty_params(true);
+                auto params = (*e)->m_params.make_empty_params(true);
                 MonomorphStatePtr   ms;
                 ms.pp_impl = &params;
-                for(const auto& vi : e->m_values )
+                for(const auto& vi : (*e)->m_values )
                 {
                     if( const auto* fcn = vi.second.opt_Function() ) {
                         Trans_Enumerate_GenericFunctionItems(state, Span(), *fcn, ms);

--- a/src/trans/monomorphise.cpp
+++ b/src/trans/monomorphise.cpp
@@ -134,13 +134,13 @@ void Trans_Monomorphise_List(const ::HIR::Crate& crate, TransList& list)
             auto name = RcString::new_interned(FMT("ConstEvalMonomorph#" << count));
             count ++;
             auto p = ::HIR::SimplePath(crate.m_crate_name, {name});
-            auto ent = std::make_unique<HIR::VisEnt<HIR::ValueItem>>(HIR::VisEnt<HIR::ValueItem> {
+            auto ent = HIR::VisEnt<HIR::ValueItem> {
                 HIR::Publicity::new_global(),
-                HIR::ValueItem(::HIR::Static(HIR::Linkage(), false, std::move(type), HIR::ExprPtr()))
-                });
+                HIR::ValueItem(box$(::HIR::Static(HIR::Linkage(), false, std::move(type), HIR::ExprPtr())))
+                };
             
             {
-                auto& s = ent->ent.as_Static();
+                auto& s = *ent.ent.as_Static();
                 s.m_value_generated = true;
                 s.m_value_res = std::move(value);
                 s.m_save_literal = false;


### PR DESCRIPTION
Wrap individual items in `HIR::TypeItem` and `HIR::ValueItem` in `unique_ptr` to save memory.

Testing with `libcargo` shows total memory usage after `Expand` (i.e. after all dependent crates loaded) decreasing from 1540MiB to 1100MiB due to the large number of `Import` variants not wasting 100s of bytes each.

Still working on some more minor space improvements (e.g. in MIR)