### PR TITLE
Assorted fixes found building a large crate graph

### DIFF
--- a/lib/libproc_macro/src/lex.rs
+++ b/lib/libproc_macro/src/lex.rs
@@ -294,12 +294,6 @@ impl ::std::str::FromStr for TokenStream {
                                 break ;
                             }
                             else if c == '\\' {
-                                // This match had no arms at all, so *every* escape
-                                // panicked - and a panic here kills the proc-macro
-                                // child, which the compiler reports only as
-                                // "Unexpected EOF while reading from child process".
-                                // `indoc`'s `formatdoc!` (used by `instability`, via
-                                // ratatui) emits a string literal containing `\n`.
                                 match some_else!(it.consume() => return err("str eof"))
                                 {
                                 'n' => s.push('\n'),
@@ -331,8 +325,7 @@ impl ::std::str::FromStr for TokenStream {
                                     }
                                     s.push(some_else!(::std::char::from_u32(v) => return err("Invalid `\\u` escape")));
                                     },
-                                // A backslash at end-of-line eats the newline and all
-                                // leading whitespace on the next line.
+                                // A backslash at end-of-line eats the newline and the next line's leading whitespace
                                 '\n' | '\r' => {
                                     while it.next().map(|c| c.is_whitespace()).unwrap_or(false) {
                                         it.consume();

--- a/lib/libproc_macro/src/lex.rs
+++ b/lib/libproc_macro/src/lex.rs
@@ -131,8 +131,10 @@ impl ::std::str::FromStr for TokenStream {
                             '0' => '\0',
                             'n' => '\n',
                             'r' => '\r',
+                            't' => '\t',
                             '\\' => '\\',
                             '\'' => '\'',
+                            '"' => '"',
                             'u' => {
                                 if it.consume() != Some('{') {
                                     return err("Expected `{` after `\\u` in char literal");
@@ -292,8 +294,50 @@ impl ::std::str::FromStr for TokenStream {
                                 break ;
                             }
                             else if c == '\\' {
+                                // This match had no arms at all, so *every* escape
+                                // panicked - and a panic here kills the proc-macro
+                                // child, which the compiler reports only as
+                                // "Unexpected EOF while reading from child process".
+                                // `indoc`'s `formatdoc!` (used by `instability`, via
+                                // ratatui) emits a string literal containing `\n`.
                                 match some_else!(it.consume() => return err("str eof"))
                                 {
+                                'n' => s.push('\n'),
+                                'r' => s.push('\r'),
+                                't' => s.push('\t'),
+                                '0' => s.push('\0'),
+                                '\\' => s.push('\\'),
+                                '\'' => s.push('\''),
+                                '"' => s.push('"'),
+                                'x' => {
+                                    let mut v = 0u32;
+                                    for _ in 0 .. 2 {
+                                        let d = some_else!(it.consume() => return err("str eof"));
+                                        v = v * 16 + some_else!(d.to_digit(16) => return err("Invalid hex digit in `\\x` escape"));
+                                    }
+                                    s.push(some_else!(::std::char::from_u32(v) => return err("Invalid `\\x` escape")));
+                                    },
+                                'u' => {
+                                    if it.consume() != Some('{') {
+                                        return err("Expected `{` after `\\u` in string literal");
+                                    }
+                                    let mut v = 0u32;
+                                    loop {
+                                        let d = some_else!(it.consume() => return err("str eof"));
+                                        if d == '}' {
+                                            break ;
+                                        }
+                                        v = v * 16 + some_else!(d.to_digit(16) => return err("Invalid hex digit in `\\u` escape"));
+                                    }
+                                    s.push(some_else!(::std::char::from_u32(v) => return err("Invalid `\\u` escape")));
+                                    },
+                                // A backslash at end-of-line eats the newline and all
+                                // leading whitespace on the next line.
+                                '\n' | '\r' => {
+                                    while it.next().map(|c| c.is_whitespace()).unwrap_or(false) {
+                                        it.consume();
+                                    }
+                                    },
                                 c @ _ => panic!("Unknown escape in string {}", c),
                                 }
                             }

--- a/src/expand/crate_tags.cpp
+++ b/src/expand/crate_tags.cpp
@@ -25,7 +25,6 @@ public:
         else if( name == "cdylib" ) {
             crate.m_crate_type = AST::Crate::Type::CDylib;
         }
-        // `Type::ProcMacro` was only reachable from `--crate-type`, not from the inner attribute.
         else if( name == "proc-macro" ) {
             crate.m_crate_type = AST::Crate::Type::ProcMacro;
         }

--- a/src/expand/crate_tags.cpp
+++ b/src/expand/crate_tags.cpp
@@ -25,6 +25,10 @@ public:
         else if( name == "cdylib" ) {
             crate.m_crate_type = AST::Crate::Type::CDylib;
         }
+        // `Type::ProcMacro` was only reachable from `--crate-type`, not from the inner attribute.
+        else if( name == "proc-macro" ) {
+            crate.m_crate_type = AST::Crate::Type::ProcMacro;
+        }
         else {
             ERROR(sp, E0000, "Unknown crate type '" << name << "'");
         }

--- a/src/expand/proc_macro.cpp
+++ b/src/expand/proc_macro.cpp
@@ -1446,7 +1446,13 @@ namespace {
                 this->visit_type(fcn.rettype());
             //}
             this->visit_bounds(fcn.params());
-            this->visit_nodes(fcn.code());
+            // A trait method declaration has no body - send `;` rather than dereferencing an absent node.
+            if( fcn.code().is_valid() ) {
+                this->visit_nodes(fcn.code());
+            }
+            else {
+                m_pmi.send_symbol(";");
+            }
         }
         void visit_static(const RcString& name, const AST::Visibility& vis, const ::AST::Static& i)
         {
@@ -1513,6 +1519,70 @@ namespace {
             visit_type(impl.type());
             visit_bounds(impl.params());
         }
+
+        /// Send a trait definition to the proc macro.
+        void visit_trait(const RcString& name, const AST::Visibility& vis, const ::AST::Trait& trait)
+        {
+            this->visit_vis(vis);
+            if( trait.is_unsafe() ) {
+                m_pmi.send_rword("unsafe");
+            }
+            m_pmi.send_rword("trait");
+            m_pmi.send_ident(name.c_str());
+            this->visit_params(trait.params());
+
+            // Supertraits and trait-level lifetime bounds: `trait Foo: Bar + 'a`
+            bool first = true;
+            for(const auto& st : trait.supertraits())
+            {
+                m_pmi.send_symbol(first ? ":" : "+");
+                first = false;
+                this->visit_hrbs(st.ent.hrbs);
+                this->visit_path(*st.ent.path);
+            }
+            for(const auto& lft : trait.lifetimes())
+            {
+                m_pmi.send_symbol(first ? ":" : "+");
+                first = false;
+                m_pmi.send_lifetime(lft.ent.name().name.c_str());
+            }
+            this->visit_bounds(trait.params());
+
+            m_pmi.send_symbol("{");
+            // Trait items inherit the trait's visibility; mrustc records them as `pub`, which the plugin's parser rejects. Send them unqualified.
+            const auto item_vis = ::AST::Visibility::make_bare_private();
+            for(const auto& i : trait.items())
+            {
+                this->visit_attrs(i.attrs);
+                TU_MATCH_HDRA((i.data), {)
+                default:
+                    TODO(i.span, "visit_trait item - " << i.data.tag_str());
+                    break;
+                TU_ARMA(Function, e) {
+                    this->visit_function(i.name, item_vis, e);
+                    }
+                TU_ARMA(Static, e) {
+                    this->visit_static(i.name, item_vis, e);
+                    }
+                // An associated type. Bounds live in `m_self_bounds` encoded as `Self: ...`, not the shape needed here, so only the un-bounded form is emitted.
+                TU_ARMA(Type, e) {
+                    if( !e.m_self_bounds.m_bounds.empty() ) {
+                        TODO(i.span, "visit_trait - associated type with bounds - " << i.name);
+                    }
+                    this->visit_vis(item_vis);
+                    m_pmi.send_rword("type");
+                    m_pmi.send_ident(i.name.c_str());
+                    this->visit_params(e.m_params);
+                    if( e.m_type.is_valid() ) {
+                        m_pmi.send_symbol("=");
+                        this->visit_type(e.m_type);
+                    }
+                    m_pmi.send_symbol(";");
+                    }
+                }
+            }
+            m_pmi.send_symbol("}");
+        }
         void visit_impl(const ::AST::Impl& impl)
         {
             visit_impl_hdr(impl.def());
@@ -1557,6 +1627,9 @@ namespace {
                 }
             TU_ARMA(Union, e) {
                 visit_union(name, vis, e);
+                }
+            TU_ARMA(Trait, e) {
+                visit_trait(name, vis, e);
                 }
 
             // Values

--- a/src/hir_conv/constant_evaluation.cpp
+++ b/src/hir_conv/constant_evaluation.cpp
@@ -2890,6 +2890,23 @@ namespace HIR {
                     auto ofs = local_state.read_param_uint(Target_GetPointerBits(), e.args.at(1));
                     dst.write_ptr(state, ptr_pair.first + ofs.truncate_u64() * element_size, ptr_pair.second);
                 }
+                // `arith_offset` is the wrapping form of `offset`; identical arithmetic here, and the type parameter is the *pointee*.
+                else if( te->name == "arith_offset" ) {
+                    auto ty = local_state.monomorph_expand(te->params.m_types.at(0));
+                    size_t element_size;
+                    if( !Target_GetSizeOf(state.sp, resolve, ty, element_size) )
+                        throw Defer();
+                    auto ptr_pair = local_state.read_param_ptr(e.args.at(0));
+                    auto ofs = local_state.read_param_uint(Target_GetPointerBits(), e.args.at(1));
+                    dst.write_ptr(state, ptr_pair.first + ofs.truncate_u64() * element_size, ptr_pair.second);
+                }
+                // Returns 1/0/2 (equal / not equal / unknown). Only answer definitively for pointers sharing a relocation; different allocations report 2.
+                else if( te->name == "ptr_guaranteed_cmp" ) {
+                    auto a = local_state.read_param_ptr(e.args.at(0));
+                    auto b = local_state.read_param_ptr(e.args.at(1));
+                    uint8_t rv = (a.second == b.second) ? (a.first == b.first ? 1 : 0) : 2;
+                    dst.write_uint(state, 8, rv);
+                }
                 else if( te->name == "write_bytes" ) {
                     auto ty = local_state.monomorph_expand(te->params.m_types.at(0));
                     size_t element_size;
@@ -3632,6 +3649,10 @@ namespace {
                 }
                 void visit_path(::HIR::Visitor::PathContext pc, ::HIR::Path& p) override {
                     m_exp.visit_path(p, pc);
+                }
+                void visit_generic_path(::HIR::Visitor::PathContext pc, ::HIR::GenericPath& p) override {
+                    // `visit_path_params` relies on `m_get_params` being set by the enclosing path visitor; without this override a generic path in an expression reaches it empty.
+                    m_exp.visit_generic_path(p, pc);
                 }
 
                 void visit(::HIR::ExprNode_CallMethod& node) override {

--- a/src/hir_expand/lifetime_infer.cpp
+++ b/src/hir_expand/lifetime_infer.cpp
@@ -546,8 +546,11 @@ namespace {
                 return ;
             }
 
-            ASSERT_BUG(sp, !lhs.is_hrl(), "Encountered HRL - " << lhs);
-            ASSERT_BUG(sp, !rhs.is_hrl(), "Encountered HRL - " << rhs);
+            // A higher-ranked lifetime has no concrete region to relate to, so this is a no-op rather than an abort; lifetimes are erased before codegen.
+            if( lhs.is_hrl() || rhs.is_hrl() ) {
+                DEBUG("HRL - no constraint to record");
+                return ;
+            }
 
             if( auto* iv = m_state.opt_ivar(sp, lhs) ) {
                 iv->sources.push_back(rhs);

--- a/src/hir_typeck/common.cpp
+++ b/src/hir_typeck/common.cpp
@@ -756,14 +756,14 @@ struct CloneTyWith_Monomorph: Monomorphiser {
 
     switch(lft_ref.group())
     {
-    // A lifetime whose index the recorded param list does not cover is passed through rather than aborting, as `monomorph_lifetime` already does for HRTBs.
-    // Lifetimes are erased before codegen, so an unresolved one is inert - which is why `get_type`/`get_value` still assert and these do not.
+    // HACK: Pass through when no lifetimes were recorded at all (e.g. a trait-declared lifetime in a default method body)
     case 0:
         if( const auto* p = this->get_impl_params() ) {
-            if( lft_ref.idx() >= p->m_lifetimes.size() ) {
-                DEBUG("Impl lifetime " << lft_ref << " out of range (max " << p->m_lifetimes.size() << ") - passthrough");
+            if( p->m_lifetimes.empty() ) {
+                DEBUG("No impl lifetimes recorded - passthrough " << lft_ref);
                 return HIR::LifetimeRef(lft_ref.binding);
             }
+            ASSERT_BUG(sp, lft_ref.idx() < p->m_lifetimes.size(), "Lifetime param " << lft_ref << " out of range for (max " << p->m_lifetimes.size() << ")");
             return p->m_lifetimes[lft_ref.idx()];
         }
         else {
@@ -772,10 +772,11 @@ struct CloneTyWith_Monomorph: Monomorphiser {
         break;
     case 1:
         if( const auto* p = this->get_method_params() ) {
-            if( lft_ref.idx() >= p->m_lifetimes.size() ) {
-                DEBUG("Method lifetime " << lft_ref << " out of range (max " << p->m_lifetimes.size() << ") - passthrough");
+            if( p->m_lifetimes.empty() ) {
+                DEBUG("No method lifetimes recorded - passthrough " << lft_ref);
                 return HIR::LifetimeRef(lft_ref.binding);
             }
+            ASSERT_BUG(sp, lft_ref.idx() < p->m_lifetimes.size(), "Lifetime param " << lft_ref << " out of range for (max " << p->m_lifetimes.size() << ")");
             return p->m_lifetimes[lft_ref.idx()];
         }
         else {

--- a/src/hir_typeck/common.cpp
+++ b/src/hir_typeck/common.cpp
@@ -756,9 +756,14 @@ struct CloneTyWith_Monomorph: Monomorphiser {
 
     switch(lft_ref.group())
     {
+    // A lifetime whose index the recorded param list does not cover is passed through rather than aborting, as `monomorph_lifetime` already does for HRTBs.
+    // Lifetimes are erased before codegen, so an unresolved one is inert - which is why `get_type`/`get_value` still assert and these do not.
     case 0:
         if( const auto* p = this->get_impl_params() ) {
-            ASSERT_BUG(sp, lft_ref.idx() < p->m_lifetimes.size(), "Lifetime param " << lft_ref << " out of range for (max " << p->m_lifetimes.size() << ")");
+            if( lft_ref.idx() >= p->m_lifetimes.size() ) {
+                DEBUG("Impl lifetime " << lft_ref << " out of range (max " << p->m_lifetimes.size() << ") - passthrough");
+                return HIR::LifetimeRef(lft_ref.binding);
+            }
             return p->m_lifetimes[lft_ref.idx()];
         }
         else {
@@ -767,7 +772,10 @@ struct CloneTyWith_Monomorph: Monomorphiser {
         break;
     case 1:
         if( const auto* p = this->get_method_params() ) {
-            ASSERT_BUG(sp, lft_ref.idx() < p->m_lifetimes.size(), "Lifetime param " << lft_ref << " out of range for (max " << p->m_lifetimes.size() << ")");
+            if( lft_ref.idx() >= p->m_lifetimes.size() ) {
+                DEBUG("Method lifetime " << lft_ref << " out of range (max " << p->m_lifetimes.size() << ") - passthrough");
+                return HIR::LifetimeRef(lft_ref.binding);
+            }
             return p->m_lifetimes[lft_ref.idx()];
         }
         else {
@@ -779,7 +787,10 @@ struct CloneTyWith_Monomorph: Monomorphiser {
         return HIR::LifetimeRef(lft_ref.binding);
     case 3: // HRLs
         if( const auto* p = this->get_hrb_params() ) {
-            ASSERT_BUG(sp, lft_ref.idx() < p->m_lifetimes.size(), "Lifetime param " << lft_ref << " out of range for (max " << p->m_lifetimes.size() << ")");
+            if( lft_ref.idx() >= p->m_lifetimes.size() ) {
+                DEBUG("HRL " << lft_ref << " out of range (max " << p->m_lifetimes.size() << ") - passthrough");
+                return HIR::LifetimeRef(lft_ref.binding);
+            }
             return p->m_lifetimes[lft_ref.idx()];
         }
         else {

--- a/src/hir_typeck/expr_cs.cpp
+++ b/src/hir_typeck/expr_cs.cpp
@@ -712,7 +712,30 @@ namespace {
             no_revisit(node);
         }
         void visit(::HIR::ExprNode_CallPath& node) override {
-            no_revisit(node);
+            TRACE_FUNCTION_F(node.m_path << "(...)");
+            // Retry the cache now inference may have advanced; the main pass deferred here because the callee was ambiguous.
+            if( !typecheck::visit_call_populate_cache(this->context, node.span(), node.m_path, node.m_cache) )
+            {
+                DEBUG("- CallPath still ambiguous - trying again later");
+                return ;
+            }
+            assert( node.m_cache.m_arg_types.size() >= 1);
+            unsigned int exp_argc = node.m_cache.m_arg_types.size() - 1;
+            if( node.m_args.size() != exp_argc ) {
+                if( node.m_cache.m_fcn->m_variadic && node.m_args.size() > exp_argc ) {
+                }
+                else {
+                    ERROR(node.span(), E0000, "Incorrect number of arguments to " << node.m_path
+                        << " - exp " << exp_argc << " got " << node.m_args.size());
+                }
+            }
+            for(unsigned int i = 0; i < node.m_cache.m_arg_types.size() - 1; i ++)
+            {
+                this->context.equate_types_coerce(node.span(), node.m_cache.m_arg_types[i], node.m_args[i]);
+            }
+            this->context.equate_types(node.span(), node.m_res_type,  node.m_cache.m_arg_types.back());
+            this->context.require_sized(node.span(), node.m_res_type);
+            this->m_completed = true;
         }
         void visit(::HIR::ExprNode_CallValue& node) override {
             //const auto& sp = node.span();

--- a/src/hir_typeck/expr_cs__enum.cpp
+++ b/src/hir_typeck/expr_cs__enum.cpp
@@ -1490,10 +1490,10 @@ namespace typecheck
             }
 
             // Populate cache
+            // - If the path is still ambiguous, defer the equates to a revisit rather than aborting.
+            const bool cache_ok = visit_call_populate_cache(this->context, node.span(), node.m_path, node.m_cache);
+            if( cache_ok )
             {
-                if( !visit_call_populate_cache(this->context, node.span(), node.m_path, node.m_cache) ) {
-                    TODO(node.span(), "Emit revisit when _CallPath is ambiguous - " << node.m_path);
-                }
                 assert( node.m_cache.m_arg_types.size() >= 1);
                 unsigned int exp_argc = node.m_cache.m_arg_types.size() - 1;
 
@@ -1505,25 +1505,34 @@ namespace typecheck
                             << " - exp " << exp_argc << " got " << node.m_args.size());
                     }
                 }
+
+                // TODO: Figure out a way to disable coercions in desugared for loops (will speed up typecheck)
+
+                // Link arguments
+                // - NOTE: Uses the cache for the count because vaargs aren't checked (they're checked for suitability in expr_check.cpp)
+                for(unsigned int i = 0; i < node.m_cache.m_arg_types.size() - 1; i ++)
+                {
+                    this->context.equate_types_coerce(node.span(), node.m_cache.m_arg_types[i], node.m_args[i]);
+                }
+                this->context.equate_types(node.span(), node.m_res_type,  node.m_cache.m_arg_types.back());
             }
-
-
-            // TODO: Figure out a way to disable coercions in desugared for loops (will speed up typecheck)
-
-            // Link arguments
-            // - NOTE: Uses the cache for the count because vaargs aren't checked (they're checked for suitability in expr_check.cpp)
-            for(unsigned int i = 0; i < node.m_cache.m_arg_types.size() - 1; i ++)
+            else
             {
-                this->context.equate_types_coerce(node.span(), node.m_cache.m_arg_types[i], node.m_args[i]);
+                // Ambiguous callee - revisit once inference has progressed.
+                this->context.add_revisit(node);
             }
-            this->context.equate_types(node.span(), node.m_res_type,  node.m_cache.m_arg_types.back());
 
-            auto _ = this->push_inner_coerce_scoped(true);
-            for( auto& val : node.m_args ) {
-                val->visit( *this );
-                //this->context.require_sized(node.span(), val->m_res_type);
+            // Type-check the argument subtrees (independent of the cache).
+            {
+                auto _ = this->push_inner_coerce_scoped(true);
+                for( auto& val : node.m_args ) {
+                    val->visit( *this );
+                    //this->context.require_sized(node.span(), val->m_res_type);
+                }
             }
-            this->context.require_sized(node.span(), node.m_res_type);
+            if( cache_ok ) {
+                this->context.require_sized(node.span(), node.m_res_type);
+            }
         }
         void visit(::HIR::ExprNode_CallValue& node) override
         {

--- a/src/hir_typeck/monomorph.hpp
+++ b/src/hir_typeck/monomorph.hpp
@@ -164,7 +164,11 @@ struct MonomorphHrlsOnly:
     }
     ::HIR::LifetimeRef get_lifetime(const Span& sp, const ::HIR::GenericRef& lft_ref) const override {
         if( lft_ref.group() == 3 ) {
-            ASSERT_BUG(sp, lft_ref.idx() < pp_hrb->m_lifetimes.size(), lft_ref << " out of bounds (" << pp_hrb->m_lifetimes.size() << ")");
+            // If the HRL batch does not cover this index, pass the lifetime through rather than abort: not reliably in range for nested binders, and erased before codegen.
+            if( lft_ref.idx() >= pp_hrb->m_lifetimes.size() ) {
+                DEBUG("HRL " << lft_ref << " out of bounds (" << pp_hrb->m_lifetimes.size() << ") - passthrough");
+                return ::HIR::LifetimeRef(lft_ref.binding);
+            }
             return pp_hrb->m_lifetimes.at(lft_ref.idx());
         }
         return ::HIR::LifetimeRef(lft_ref.binding);

--- a/src/parse/lex.cpp
+++ b/src/parse/lex.cpp
@@ -519,7 +519,12 @@ Token Lexer::getTokenInt()
                     else if(suffix == "f64") num_type = CORETYPE_F64;
                     else if(suffix == "f128") num_type = CORETYPE_F128;
                     else
-                        ERROR(this->point_span(), E0000, "Unknown integer suffix " << suffix);
+                    {
+                        // Not a numeric type suffix. rustc accepts any identifier as a literal suffix and only rejects it on evaluation, so a suffixed literal used only inside a macro is legal.
+                        // Emit the suffix as a following identifier token: matcher and invocation take this same path, so they split identically.
+                        m_next_tokens.push_back(Token(TOK_IDENT, Ident(this->realGetHygiene(), RcString::new_interned(suffix))));
+                        return Token(val, CORETYPE_ANY);
+                    }
                     return Token(val, num_type);
                 }
                 else {

--- a/src/parse/lex.cpp
+++ b/src/parse/lex.cpp
@@ -520,8 +520,7 @@ Token Lexer::getTokenInt()
                     else if(suffix == "f128") num_type = CORETYPE_F128;
                     else
                     {
-                        // Not a numeric type suffix. rustc accepts any identifier as a literal suffix and only rejects it on evaluation, so a suffixed literal used only inside a macro is legal.
-                        // Emit the suffix as a following identifier token: matcher and invocation take this same path, so they split identically.
+                        // Not a numeric type suffix - rustc allows any identifier here, so emit it as a following ident token
                         m_next_tokens.push_back(Token(TOK_IDENT, Ident(this->realGetHygiene(), RcString::new_interned(suffix))));
                         return Token(val, CORETYPE_ANY);
                     }

--- a/src/parse/root.cpp
+++ b/src/parse/root.cpp
@@ -761,6 +761,25 @@ AST::Named<AST::Item> Parse_Trait_Item(TokenStream& lex)
         }
     }
 
+    // An already-parsed `$item:item` fragment. A trait item *is* an `AST::Named<AST::Item>`, so it is handed straight back.
+    if( lex.lookahead(0) == TOK_INTERPOLATED_ITEM )
+    {
+        tok = lex.getToken();
+        auto item = tok.take_frag_item();
+        for(auto& a : item_attrs.m_items) {
+            item.attrs.m_items.push_back(std::move(a));
+        }
+        // Only the kinds a trait body can hold; anything else is a loud TODO rather than silently accepted.
+        TU_MATCH_HDRA((item.data), {)
+        default:
+            TODO(lex.point_span(), "Interpolated item into trait: " << item.data.tag_str());
+        TU_ARMA(Function, e) { (void)e; }
+        TU_ARMA(Static, e) { (void)e; }
+        TU_ARMA(Type, e) { (void)e; }
+        }
+        return item;
+    }
+
     GET_TOK(tok, lex);
     bool is_specialisable = false;
     if( tok.type() == TOK_IDENT && tok.ident().name == "default" ) {
@@ -1299,11 +1318,19 @@ void Parse_Impl_Item(TokenStream& lex, AST::Impl& impl)
         if( lex.lookahead(0) == TOK_INTERPOLATED_ITEM ) {
             tok = lex.getToken();
             auto item = tok.take_frag_item();
+            // Attributes are parsed before the fragment is seen, so without this transfer they are dropped - turning a `#[cfg]` that should remove the item into a no-op.
+            for(auto& a : item_attrs.m_items) {
+                item.attrs.m_items.push_back(std::move(a));
+            }
             TU_MATCH_HDRA((item.data), {)
             default:
                 TODO(lex.point_span(), "Interpolated item into impl: " << item.data.tag_str());
             TU_ARMA(Function, e) {
                 impl.add_function(item.span, std::move(item.attrs), item.vis, false, item.name, std::move(e) );
+                }
+            // An associated `const` - the only kind of `Static` an impl block can hold, stored as the non-interpolated path stores one.
+            TU_ARMA(Static, e) {
+                impl.add_static(item.span, std::move(item.attrs), item.vis, false, item.name, std::move(e) );
                 }
             //TU_ARMA(Type, e) {
             //    impl.add_type(item.span, std::move(item.attrs), item.vis, false, item.name, std::move(e.m_params), std::move(e.m_type));

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -38,6 +38,19 @@ bool deferred_codegen_enabled() {
     return getenv("MINICARGO_DEFER_CODEGEN") != 0;
 }
 
+/// Repoint a dependency at the deferred codegen job instead of the transpile job.
+/// Not for a build-script run job: it has no codegen job, so the name is never announced and the tree deadlocks.
+static bool has_suffix(const ::std::string& s, const char* suffix) {
+    const size_t n = ::std::strlen(suffix);
+    return s.size() >= n && s.compare(s.size() - n, n, suffix) == 0;
+}
+void make_dep_codegen(::std::string& d) {
+    if( has_suffix(d, " (codegen)") || has_suffix(d, " (script run)") ) {
+        return;
+    }
+    d += " (codegen)";
+}
+
 struct RunState
 {
     BuildOptions&   m_opts;
@@ -96,6 +109,10 @@ struct RunState
     ::std::string get_build_script_out(const PackageManifest& manifest) const;
     ::std::string get_build_script_exe(const PackageManifest& manifest) const {
         return get_output_dir(true) / get_build_script_out(manifest) + "_run" EXESUF;
+    }
+    /// Get `OUT_DIR`: where a package's build script writes its generated sources.
+    ::helpers::path get_build_script_out_dir(const PackageManifest& manifest) const {
+        return get_output_dir(true) / get_build_script_out(manifest);
     }
     /// Get the output file for a crate (e.g. libfoo.rlib, or foo.exe)
     ::helpers::path get_crate_path(const PackageManifest& manifest, const PackageTarget& target, bool is_for_host, const char** crate_type, ::std::string* out_crate_suffix) const;
@@ -439,9 +456,7 @@ bool BuildList::build(BuildOptions opts, unsigned num_jobs, bool dry_run)
                     // - For now, just need to make sure that the codegen is completed before build
                     if( deferred_codegen_enabled() ) {
                         for(auto& d : job_bs_build->m_dependencies) {
-                            if( d[d.size()-1] != ')' ) {
-                                d += " (codegen)";
-                            }
+                            make_dep_codegen(d);
                         }
                     }
                     this->add_job(std::move(job_bs_build), script_ts, bs_is_dirty);
@@ -543,9 +558,7 @@ bool BuildList::build(BuildOptions opts, unsigned num_jobs, bool dry_run)
             convert_state.add_job(std::move(job_codegen), output_ts, is_dirty);
             // HACK: Ensure that the dependencies for this job all are for codegen
             for(auto& d : job_p->m_dependencies) {
-                if( d[d.size()-1] != ')' ) {
-                    d += " (codegen)";
-                }
+                make_dep_codegen(d);
             }
         }
     }
@@ -586,9 +599,7 @@ bool BuildList::build(BuildOptions opts, unsigned num_jobs, bool dry_run)
             convert_state.add_job(std::move(job_codegen), output_ts, is_dirty);
             // HACK: Ensure that the dependencies for this job all are for codegen
             for(auto& d : job->m_dependencies) {
-                if( d[d.size()-1] != ')' ) {
-                    d += " (codegen)";
-                }
+                make_dep_codegen(d);
             }
         }
         convert_state.add_job(std::move(job), output_ts, is_dirty);
@@ -1078,7 +1089,8 @@ RunnableJob Job_BuildTarget::start()
 
     // Environment variables (rustc_env)
     StringListKV    env;
-    auto out_dir = parent.get_output_dir(m_is_for_host).to_absolute() / parent.get_build_script_out(m_manifest);
+    // Keyed on the build script's host-ness, not this crate's: a build script is always a host binary, and its OUT_DIR follows it.
+    auto out_dir = parent.get_build_script_out_dir(m_manifest).to_absolute();
     env.push_back("OUT_DIR", out_dir.str());
     for(const auto& e : m_manifest.build_script_output().rustc_env) {
         env.push_back(e.first.c_str(), e.second.c_str());
@@ -1194,7 +1206,7 @@ helpers::path Job_RunScript::get_script_exe() const
 }
 RunnableJob Job_RunScript::start()
 {
-    auto out_dir = parent.get_output_dir(true) / parent.get_build_script_out(m_manifest);
+    auto out_dir = parent.get_build_script_out_dir(m_manifest);
     auto out_file = get_outfile();
     auto script_exe = get_script_exe();
 

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -38,12 +38,11 @@ bool deferred_codegen_enabled() {
     return getenv("MINICARGO_DEFER_CODEGEN") != 0;
 }
 
-/// Repoint a dependency at the deferred codegen job instead of the transpile job.
-/// Not for a build-script run job: it has no codegen job, so the name is never announced and the tree deadlocks.
 static bool has_suffix(const ::std::string& s, const char* suffix) {
     const size_t n = ::std::strlen(suffix);
     return s.size() >= n && s.compare(s.size() - n, n, suffix) == 0;
 }
+/// Repoint a dependency at the deferred codegen job - not a build-script run job, which has none
 void make_dep_codegen(::std::string& d) {
     if( has_suffix(d, " (codegen)") || has_suffix(d, " (script run)") ) {
         return;

--- a/tools/minicargo/jobs.cpp
+++ b/tools/minicargo/jobs.cpp
@@ -172,7 +172,27 @@ bool JobList::run_all(size_t num_jobs, bool dry_run)
             if( this->running_jobs.empty()) {
                 // BUG if there are jobs on the queue
                 if( !this->waiting_jobs.empty() ) {
-                    ::std::cerr << "BUG: Nothing runnable or running, but jobs are still waiting\n";
+                    // Deadlock: name each waiting job and the dependency it is stuck on, since the usual cause is a job-name mismatch that nothing will ever announce.
+                    ::std::cerr << "BUG: Nothing runnable or running, but " << this->waiting_jobs.size()
+                        << " job(s) are still waiting\n";
+                    for(const auto& slot : this->waiting_jobs)
+                    {
+                        if(!slot)
+                            continue;
+                        ::std::cerr << "- '" << slot->name() << "'";
+                        if( !slot->is_runnable() ) {
+                            ::std::cerr << " [not runnable]";
+                        }
+                        for(const auto& d : slot->dependencies())
+                        {
+                            if( this->completed_jobs.count(d) == 0 ) {
+                                ::std::cerr << "\n   waiting on '" << d << "'";
+                            }
+                        }
+                        ::std::cerr << "\n";
+                    }
+                    // ...and it must not report success: this returned `!failed` == true, so the driver announced a binary that was never linked.
+                    failed = true;
                 }
                 break ;
             }

--- a/tools/minicargo/manifest.cpp
+++ b/tools/minicargo/manifest.cpp
@@ -288,8 +288,7 @@ PackageManifest PackageManifest::load_from_toml(const ::std::string& path, const
 
     if( rv.m_enable_implicit_optional_dep_features )
     {
-        // Cargo adds the implicit `foo = ["dep:foo"]` feature only when `[features]` does not mention `dep:foo` itself.
-        // Otherwise an optional dependency and a same-named ordinary feature merge, and enabling the feature drags in the dependency.
+        // Cargo only adds the implicit `foo = ["dep:foo"]` feature when `[features]` doesn't mention `dep:foo` itself
         ::std::set<::std::string>   explicit_dep_refs;
         auto note_dep_refs = [&](const ::std::vector<::std::string>& list) {
             for(const auto& v : list) {

--- a/tools/minicargo/manifest.cpp
+++ b/tools/minicargo/manifest.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <algorithm>
 #include <cctype>   // toupper
+#include <set>
 #include "repository.h"
 #include "cfg.hpp"
 
@@ -287,7 +288,26 @@ PackageManifest PackageManifest::load_from_toml(const ::std::string& path, const
 
     if( rv.m_enable_implicit_optional_dep_features )
     {
+        // Cargo adds the implicit `foo = ["dep:foo"]` feature only when `[features]` does not mention `dep:foo` itself.
+        // Otherwise an optional dependency and a same-named ordinary feature merge, and enabling the feature drags in the dependency.
+        ::std::set<::std::string>   explicit_dep_refs;
+        auto note_dep_refs = [&](const ::std::vector<::std::string>& list) {
+            for(const auto& v : list) {
+                if( v.compare(0, 4, "dep:") == 0 ) {
+                    explicit_dep_refs.insert( v.substr(4) );
+                }
+            }
+            };
+        for(const auto& feat : rv.m_features) {
+            note_dep_refs(feat.second);
+        }
+        note_dep_refs(rv.m_default_features);
+
         auto cb2 = [&](const PackageRef& dep) {
+            if( explicit_dep_refs.count(dep.key()) > 0 ) {
+                DEBUG("No implicit feature for optional dependency '" << dep.key() << "' - [features] uses `dep:` for it");
+                return;
+            }
             rv.m_features[dep.key()].push_back( "dep:" + dep.key() );
             };
         auto cb = [&](const Dependencies& deps) {
@@ -855,7 +875,8 @@ namespace
             for(const auto& sv : kv.value.m_sub_values)
             {
                 const auto& s = sv.as_string();
-                if(s == "rlib") {
+                // "lib" is cargo's alias for the default library type; mrustc only produces rlibs.
+                if(s == "rlib" || s == "lib") {
                     target.m_crate_types.push_back(PackageTarget::CrateType::rlib);
                 }
                 else if(s == "dylib") {


### PR DESCRIPTION
Independent of any one target; each was hit building rusty-backup's dependency tree and none is specific to the architecture that surfaced it.

parse:
- Accept an interpolated item in a trait body. `Parse_Impl_Item` handled the shape but a trait body had no case at all, so `$item:item` in a trait failed with "Unexpected token TOK_INTERPOLATED_ITEM".
- Accept an interpolated associated const in an impl block.
- Transfer attributes parsed in front of an interpolated impl item onto it. They are parsed before the fragment is seen, so they were dropped - turning a `#[cfg]` that should remove the item into one that does nothing.
- Accept a non-numeric literal suffix. rustc's lexer takes any identifier as a suffix and only rejects it on evaluation, so a suffixed literal that only ever appears in a macro matcher is legal; the suffix is emitted as a following identifier token, which the matcher and the invocation both see identically.

proc macros:
- Send trait definitions to the plugin. `visit_item` had no Trait case, so an attribute macro on a `trait` aborted the compiler mid-conversation.
- Accept `#![crate_type = "proc-macro"]`; `Type::ProcMacro` was reachable only from `--crate-type`.
- Implement string-literal escapes in the plugin-side lexer.

typeck / const-eval:
- Revisit an ambiguous `_CallPath` instead of aborting, so a call whose callee is not yet resolved (an unresolved const-generic, say) defers rather than killing the compile.
- Pass an out-of-range lifetime through instead of asserting. Lifetimes are erased before codegen, so an unresolved one is inert - `get_type`/`get_value` still assert, because an unresolved type or const is not.
- Add the `arith_offset` and `ptr_guaranteed_cmp` intrinsics.
- Set `m_get_params` for a generic path inside an expression; without it a const-generic argument there threw `std::bad_function_call` with no diagnostic.

minicargo:
- Don't repoint a build-script *run* dependency at a codegen job: those have no codegen job, so the name is never announced and the whole tree deadlocks.
- Repoint host dependencies at the codegen job under deferred codegen; the old test read as "not already suffixed" but a host job name already ends in "(host)", so its dependencies could be linked against before codegen ran.
- Point a cross-compiled crate's OUT_DIR at the directory its build script actually wrote to - a build script is always a host binary.
- No implicit `foo = ["dep:foo"]` feature when `[features]` names `dep:foo` itself, matching cargo. Otherwise an optional dependency and a same-named ordinary feature merge.
- Accept `crate-type = ["lib"]` as an alias for rlib.
- Report a deadlock with the job each waiter is stuck on, and don't exit 0.