### PR TITLE
Add powerpc-apple-darwin as a target

### DIFF
--- a/minicargo.mk
+++ b/minicargo.mk
@@ -225,9 +225,14 @@ $(RUSTC_SRC_TARBALL):
 rustc-$(RUSTC_VERSION)-src/extracted: $(RUSTC_SRC_TARBALL)
 	tar -xzf $(RUSTC_SRC_TARBALL)
 	touch $@
+# Compare contents, not mtimes: a checkout churns mtimes and re-patching fails.
 $(RUSTC_SRC_DL): rustc-$(RUSTC_VERSION)-src/extracted rustc-$(RUSTC_VERSION)-src.patch
-	cd $(RUSTCSRC) && patch -p0 < ../rustc-$(RUSTC_VERSION)-src.patch;
-	touch $@
+	@cmp -s rustc-$(RUSTC_VERSION)-src.patch $@ && exit 0; \
+	echo [PATCH] rustc-$(RUSTC_VERSION)-src; \
+	files=`cat $@ rustc-$(RUSTC_VERSION)-src.patch 2>/dev/null | sed -n 's|^--- |$(RUSTCSRC)|p' | sort -u`; \
+	tar -xzf $(RUSTC_SRC_TARBALL) $$files && \
+	( cd $(RUSTCSRC) && patch -p0 < ../rustc-$(RUSTC_VERSION)-src.patch ) && \
+	cp rustc-$(RUSTC_VERSION)-src.patch $@
 
 # Standard library crates
 # - libstd, libpanic_unwind, libtest and libgetopts

--- a/rustc-1.74.0-src.patch
+++ b/rustc-1.74.0-src.patch
@@ -146,3 +146,32 @@
 +#include <cstdint>
  #include <memory>
  
+
+# macos_weak only defines the fdopendir weak symbol for x86/x86_64; other macOS targets emit neither arm.
+# 10.4/10.5 have no $INODE64 variants, so the plain symbol is the correct one there.
+--- library/std/src/sys/unix/fs.rs
++++ library/std/src/sys/unix/fs.rs
+@@ -1979,6 +1979,8 @@
+             weak!(fn fdopendir(c_int) -> *mut DIR, "fdopendir$INODE64$UNIX2003");
+             #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+             weak!(fn fdopendir(c_int) -> *mut DIR, "fdopendir$INODE64");
++            #[cfg(all(target_os = "macos", not(any(target_arch = "x86", target_arch = "x86_64"))))]
++            weak!(fn fdopendir(c_int) -> *mut DIR);
+             fdopendir.get().map(|fdopendir| fdopendir(fd)).unwrap_or_else(|| {
+                 crate::sys::unix::os::set_errno(libc::ENOSYS);
+                 crate::ptr::null_mut()
+
+# The Darwin thread parker needs libdispatch (10.6+); powerpc-apple-darwin is 10.4/10.5, so use the generic pthread parker.
+--- library/std/src/sys/unix/thread_parking/mod.rs
++++ library/std/src/sys/unix/thread_parking/mod.rs
+@@ -18,6 +18,10 @@
+             target_os = "watchos",
+             target_os = "tvos",
+         ),
++        // The Darwin parker is built on libdispatch, which is 10.6+.
++        // powerpc-apple-darwin is by definition 10.4/10.5, so it falls through
++        // to the generic pthread parker.
++        not(target_arch = "powerpc"),
+         not(miri),
+     ))] {
+         mod darwin;

--- a/script-overrides/stable-1.74.0-macos-powerpc/build_compiler_builtins.txt
+++ b/script-overrides/stable-1.74.0-macos-powerpc/build_compiler_builtins.txt
@@ -1,0 +1,2 @@
+#cargo:compiler-rt=
+cargo:rustc-cfg=feature="unstable"

--- a/script-overrides/stable-1.74.0-macos-powerpc/build_libc.txt
+++ b/script-overrides/stable-1.74.0-macos-powerpc/build_libc.txt
@@ -1,0 +1,10 @@
+cargo:rustc-cfg=darwin
+cargo:rustc-cfg=libc_priv_mod_use
+cargo:rustc-cfg=libc_union
+cargo:rustc-cfg=libc_const_size_o
+cargo:rustc-cfg=libc_align
+cargo:rustc-cfg=libc_core_cvoid
+cargo:rustc-cfg=libc_packedN
+cargo:rustc-cfg=libc_cfg_target_vendor
+cargo:rustc-cfg=libc_thread_local
+cargo:rustc-cfg=libc_const_extern_fn

--- a/script-overrides/stable-1.74.0-macos-powerpc/build_std.txt
+++ b/script-overrides/stable-1.74.0-macos-powerpc/build_std.txt
@@ -1,0 +1,2 @@
+cargo:rustc-cfg=backtrace_in_libstd
+cargo:rustc-env=STD_ENV_ARCH=powerpc

--- a/script-overrides/stable-1.74.0-macos-powerpc/build_unwind.txt
+++ b/script-overrides/stable-1.74.0-macos-powerpc/build_unwind.txt
@@ -1,0 +1,1 @@
+# No output for macos

--- a/script-overrides/stable-1.74.0-macos/build_compiler_builtins.txt
+++ b/script-overrides/stable-1.74.0-macos/build_compiler_builtins.txt
@@ -1,0 +1,2 @@
+#cargo:compiler-rt=
+cargo:rustc-cfg=feature="unstable"

--- a/script-overrides/stable-1.74.0-macos/build_libc.txt
+++ b/script-overrides/stable-1.74.0-macos/build_libc.txt
@@ -1,0 +1,10 @@
+cargo:rustc-cfg=darwin
+cargo:rustc-cfg=libc_priv_mod_use
+cargo:rustc-cfg=libc_union
+cargo:rustc-cfg=libc_const_size_o
+cargo:rustc-cfg=libc_align
+cargo:rustc-cfg=libc_core_cvoid
+cargo:rustc-cfg=libc_packedN
+cargo:rustc-cfg=libc_cfg_target_vendor
+cargo:rustc-cfg=libc_thread_local
+cargo:rustc-cfg=libc_const_extern_fn

--- a/script-overrides/stable-1.74.0-macos/build_std.txt
+++ b/script-overrides/stable-1.74.0-macos/build_std.txt
@@ -1,0 +1,2 @@
+cargo:rustc-cfg=backtrace_in_libstd
+cargo:rustc-env=STD_ENV_ARCH=aarch64

--- a/script-overrides/stable-1.74.0-macos/build_unwind.txt
+++ b/script-overrides/stable-1.74.0-macos/build_unwind.txt
@@ -1,0 +1,1 @@
+# No output for macos

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1758,6 +1758,8 @@ namespace {
             ::std::vector<unsigned> fields; fields.reserve(repr->fields.size());
             ::std::vector<bool>   zsts; zsts.reserve(repr->fields.size());
             size_t max_align = 0;
+            // `max_align` is the largest natural field alignment; `c_max_align` is what the C compiler will derive for the emitted struct.
+            size_t c_max_align = 0;
             bool has_manual_align = false;
             for(const auto& ent : repr->fields)
             {
@@ -1769,12 +1771,25 @@ namespace {
                     has_manual_align = true;
                 }
                 max_align = std::max(max_align, al);
+                // Track what C will derive separately - under a capping ABI an interior over-aligned member doesn't raise it
+                {
+                    size_t al_c = al;
+                    if( Target_CapsMemberAlignment() && sz > 0 && ent.offset != 0 && al_c > 4
+                        && !Target_TypeHasUserAlignment(sp, m_resolve, ty) ) {
+                        al_c = 4;
+                    }
+                    c_max_align = std::max(c_max_align, al_c);
+                }
 
                 fields.push_back(fields.size());
                 zsts.push_back(sz == 0);
             }
-            if(packing_max_align == 0 && max_align != repr->align /*&& repr->size > 0*/) {
+            if(packing_max_align == 0 && c_max_align != repr->align /*&& repr->size > 0*/) {
                 has_manual_align = true;
+            }
+            // An align-1 type must be emitted packed - gcc takes a container's alignment from the member's natural alignment
+            if(packing_max_align == 0 && !has_manual_align && repr->align == 1 && repr->size > 1) {
+                packing_max_align = 1;
             }
             // - Sort the fields by offset
             ::std::sort(fields.begin(), fields.end(), [&](auto a, auto b){
@@ -2078,7 +2093,13 @@ namespace {
                 assert(repr->fields[i].offset == 0);
                 m_of << "\t"; emit_ctype( repr->fields[i].ty, FMT_CB(ss, ss << "var_" << i;) ); m_of << ";\n";
             }
-            m_of << "};\n";
+            m_of << "}";
+            // Pin union alignment - under the power ABI gcc takes a union's alignment from its *first* member
+            if( m_compiler == Compiler::Gcc && repr->align > 0 )
+            {
+                m_of << " __attribute__((__aligned__(" << repr->align << ")))";
+            }
+            m_of << ";\n";
             if( true && repr->size > 0 )
             {
                 m_of << "typedef char sizeof_assert_" << Trans_Mangle(p) << "[ (sizeof(union u_" << Trans_Mangle(p) << ") == " << repr->size << ") ? 1 : -1 ];\n";

--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -69,7 +69,8 @@ const TargetArch ARCH_POWERPC64LE = {
 const TargetArch ARCH_POWERPC = {
     "powerpc",
     32, true,
-    { /*atomic(u8)=*/true, true, true, false,  true },
+    // 8-byte atomics are lock-based via libatomic here, but still available: cfg'ing out AtomicU64 breaks libstd.
+    { /*atomic(u8)=*/true, true, true, true,  true },
     TargetArch::Alignments(2, 4, 8, 8, 4, 8, 4)
 };
 const TargetArch ARCH_RISCV64 = {
@@ -604,12 +605,13 @@ namespace
                 ARCH_X86_64
                 };
         }
+        // `*-apple-darwin` has an empty target_env (as in rustc); "gnu" selects glibc-only code on a platform with no glibc.
         else if(target_name == "i686-apple-darwin")
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
             // The first 32bit Intel Mac was Core Solo aka yonah. It allows to use `-march=yonah` like Rust.
             return TargetSpec {
-                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {"-march=yonah"}, {}},
+                "unix", "macos", "", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {"-march=yonah"}, {}},
                 ARCH_X86_64
                 };
         }
@@ -618,7 +620,7 @@ namespace
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
             // The first 64bit Intel Mac was Core Duo. It allows to use `-march=core2` like Rust.
             return TargetSpec {
-                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {"-march=core2"}, {}},
+                "unix", "macos", "", {CodegenMode::Gnu11, false, "x86_64-apple-darwin", {"-march=core2"}, {}},
                 ARCH_X86_64
                 };
         }
@@ -626,15 +628,16 @@ namespace
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
             return TargetSpec {
-                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "aarch64-apple-darwin", {}, {}},
+                "unix", "macos", "", {CodegenMode::Gnu11, false, "aarch64-apple-darwin", {}, {}},
                 ARCH_ARM64
                 };
         }
         else if(target_name == "powerpc-apple-darwin")
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
+            // NOTE: 32-bit PowerPC needs libatomic for the 8-byte atomics (see ARCH_POWERPC)
             return TargetSpec {
-                "unix", "macos", "gnu", {CodegenMode::Gnu11, true, "powerpc-apple-darwin", {}, {}},
+                "unix", "macos", "", {CodegenMode::Gnu11, true, "powerpc-apple-darwin", {}, {}, {"-l", "atomic"}},
                 ARCH_POWERPC
                 };
         }
@@ -642,7 +645,7 @@ namespace
         {
             // NOTE: OSX uses Mach-O binaries, which don't fully support the defaults used for GNU targets
             return TargetSpec {
-                "unix", "macos", "gnu", {CodegenMode::Gnu11, false, "powerpc64-apple-darwin", {}, {}},
+                "unix", "macos", "", {CodegenMode::Gnu11, false, "powerpc64-apple-darwin", {}, {}},
                 ARCH_POWERPC64
                 };
         }
@@ -980,10 +983,26 @@ namespace {
         size_t  size;
         size_t  align;
         HIR::TypeRef    ty;
+        /// `align` came from an explicit `repr(align(N))` somewhere inside `ty`.
+        bool    user_align = false;
     };
     ::std::ostream& operator<<(std::ostream& os, const Ent& e) {
-        os << "Ent { #" << e.field << ": s=" << e.size << " a=" << e.align << " : " << e.ty << " }";
+        os << "Ent { #" << e.field << ": s=" << e.size << " a=" << e.align << (e.user_align ? "!" : "") << " : " << e.ty << " }";
         return os;
+    }
+
+    bool make_field_ent(const Span& sp, const StaticTraitResolve& resolve, unsigned idx, ::HIR::TypeRef ty, Ent& out)
+    {
+        size_t  size, align;
+        if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size, align) )
+        {
+            DEBUG("Can't get size/align of " << ty);
+            return false;
+        }
+        out = Ent { idx, size, align, HIR::TypeRef(), false };
+        out.user_align = Target_TypeHasUserAlignment(sp, resolve, ty);
+        out.ty = mv$(ty);
+        return true;
     }
     bool struct_enumerate_fields(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, ::std::vector<Ent>& ents)
     {
@@ -1001,30 +1020,24 @@ namespace {
             unsigned int idx = 0;
             for(const auto& e : se)
             {
-                auto ty = monomorph(e.ent);
-                size_t  size, align;
-                if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size,align) )
-                {
-                    DEBUG("Can't get size/align of " << ty);
+                Ent ent;
+                if( !make_field_ent(sp, resolve, idx, monomorph(e.ent), ent) )
                     return false;
-                }
-                DEBUG("#" << idx << ": s=" << size << ",a=" << align << " " << ty);
-                ents.push_back(Ent { idx++, size, align, mv$(ty) });
+                DEBUG("#" << idx << ": " << ent);
+                idx ++;
+                ents.push_back(mv$(ent));
             }
             }
         TU_ARMA(Named, se) {
             unsigned int idx = 0;
             for(const auto& e : se)
             {
-                auto ty = monomorph(e.ty);
-                size_t  size, align;
-                if( !Target_GetSizeAndAlignOf(sp, resolve, ty, size,align) )
-                {
-                    DEBUG("Can't get size/align of " << ty);
+                Ent ent;
+                if( !make_field_ent(sp, resolve, idx, monomorph(e.ty), ent) )
                     return false;
-                }
-                DEBUG("#" << idx << " " << e.name << ": s=" << size << ",a=" << align << " " << ty);
-                ents.push_back(Ent { idx++, size, align, mv$(ty) });
+                DEBUG("#" << idx << " " << e.name << ": " << ent);
+                idx ++;
+                ents.push_back(mv$(ent));
             }
             }
         }
@@ -1082,16 +1095,20 @@ namespace {
             // PowerPC 32-bit ABI
             // First element uses natural alignment, subsequent elements with natural alignment
             // >= 4 and up to 8 use embedding = 4. Skip ZST.
-            if(Target_GetCurSpec().m_arch.m_name == "powerpc")
+            // The cap is on natural alignment only: an explicitly aligned member keeps it, as in gcc.
+            if(Target_CapsMemberAlignment())
             {
                 if ( e.size > 0 )
                 {
-                    if( !is_first_field && align >= 4 && align <= 8 )
+                    if( !is_first_field && !e.user_align && align >= 4 && align <= 8 )
                     {
                         align = 4;
                     }
                     is_first_field = false;
                 }
+            }
+            if( e.user_align ) {
+                rv.user_align = true;
             }
 
             // Increase offset to fit alignment
@@ -1127,6 +1144,8 @@ namespace {
         }
         if(forced_alignment > 0) {
             max_align = std::max(max_align, static_cast<size_t>(forced_alignment));
+            // `repr(align(N))` - this is the root of a user-alignment chain.
+            rv.user_align = true;
         }
         // If not packing (and the size isn't infinite/unsized) then round the size up to the alignment
         if( cur_ofs != SIZE_MAX )
@@ -1193,13 +1212,11 @@ namespace {
             unsigned int idx = 0;
             for(const auto& t : *te)
             {
-                size_t  size, align;
-                if( !Target_GetSizeAndAlignOf(sp, resolve, t, size,align) )
-                {
-                    DEBUG("Can't get size/align of " << t);
+                Ent ent;
+                if( !make_field_ent(sp, resolve, idx, t.clone(), ent) )
                     return nullptr;
-                }
-                ents.push_back(Ent { idx++, size, align, t.clone() });
+                idx ++;
+                ents.push_back(mv$(ent));
             }
             sorting = StructSorting::All;
         }
@@ -1847,6 +1864,9 @@ namespace {
                             // Generate raw struct reprs for all variants
                             // - Add `non_niche_offset` to all variants
                             assert(reprs.size() == variants.size());
+                            // Size/alignment of the union of the *final* variant layouts, which is what codegen emits.
+                            size_t final_size = 0;
+                            size_t final_align = 1;
                             for(size_t i = 0; i < reprs.size(); i ++)
                             {
                                 if( e[i].type != HIR::TypeRef::new_unit() )
@@ -1913,19 +1933,38 @@ namespace {
                                         assert(reprs[i]->size <= max_size);
                                         assert(reprs[i]->align <= max_align);
                                     }
+                                    final_size  = std::max(final_size , reprs[i]->size );
+                                    final_align = std::max(final_align, reprs[i]->align);
                                     set_type_repr(sp, variants[i].type, std::move(reprs[i]));
                                 }
                                 else
                                 {
                                     // Note: unit type (any empty type) doesn't need the tag added
                                     // NOTE: Unit type should already have a repr, but make sure
-                                    Target_GetTypeRepr(sp, resolve, variants[i].type);
+                                    if( const auto* r = Target_GetTypeRepr(sp, resolve, variants[i].type) ) {
+                                        final_size  = std::max(final_size , r->size );
+                                        final_align = std::max(final_align, r->align);
+                                    }
                                 }
                                 rv.fields.push_back(TypeRepr::Field { 0, mv$(variants[i].type) });
                             }
 
                             rv.size = max_size;
                             rv.align = max_align;
+
+                            // Under a capping ABI take size/align from the final variant layouts - `max_align` predates the tag field, so it over-states them
+                            if( Target_CapsMemberAlignment() && final_size > 0 )
+                            {
+                                size_t sz = final_size;
+                                while( sz % final_align != 0 )
+                                    sz ++;
+                                if( sz != rv.size || final_align != rv.align ) {
+                                    DEBUG("Capping ABI: " << ty << " " << rv.size << "/" << rv.align
+                                        << " -> " << sz << "/" << final_align << " (union of the final variants)");
+                                    rv.size = sz;
+                                    rv.align = final_align;
+                                }
+                            }
 
                             // Ensure that the tag offset is still valid
                             auto tag_offset = get_offset(sp, resolve, &rv, niche_path);
@@ -2127,6 +2166,14 @@ namespace {
                 << " }");
             }
         }
+
+        // An enum inherits user-alignment from any variant, as in gcc; every variant repr is already cached here, so this cannot recurse.
+        for(const auto& f : rv.fields) {
+            if( Target_TypeHasUserAlignment(sp, resolve, f.ty) ) {
+                rv.user_align = true;
+                break;
+            }
+        }
         return box$(rv);
     }
     ::std::unique_ptr<TypeRepr> make_type_repr_union(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
@@ -2140,6 +2187,8 @@ namespace {
         };
 
         TypeRepr  rv;
+        // codegen_c pins union alignment with an explicit `__attribute__((aligned))`, which gcc counts as user-alignment - so a union, and anything containing it, is exempt from the cap.
+        rv.user_align = true;
         for(const auto& var : unn.m_variants)
         {
             rv.fields.push_back({ 0, monomorph(var.ty) });
@@ -2155,6 +2204,10 @@ namespace {
             }
             rv.size  = ::std::max(rv.size , size );
             rv.align = ::std::max(rv.align, align);
+            // A union inherits user-alignment from any member, as in gcc.
+            if( Target_TypeHasUserAlignment(sp, resolve, rv.fields.back().ty) ) {
+                rv.user_align = true;
+            }
         }
         // Round the size to be a multiple of align
         if( rv.size % rv.align != 0 )
@@ -2218,6 +2271,31 @@ namespace {
 void Target_ForceTypeRepr(const Span& sp, const ::HIR::TypeRef& ty, TypeRepr repr)
 {
     set_type_repr(sp, ty, box$(repr));
+}
+bool Target_CapsMemberAlignment()
+{
+    return Target_GetCurSpec().m_arch.m_name == "powerpc";
+}
+bool Target_TypeHasUserAlignment(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
+{
+    // Arrays and slices inherit it from the element type, as in gcc's `layout_type`
+    if( const auto* te = ty.data().opt_Array() ) {
+        return Target_TypeHasUserAlignment(sp, resolve, te->inner);
+    }
+    if( const auto* te = ty.data().opt_Slice() ) {
+        return Target_TypeHasUserAlignment(sp, resolve, te->inner);
+    }
+    // Aggregates cache it on their repr; everything else is naturally aligned by definition
+    if( ty.data().is_Tuple() || (ty.data().is_Path() && (
+            ty.data().as_Path().binding.is_Struct()
+            || ty.data().as_Path().binding.is_Union()
+            || ty.data().as_Path().binding.is_Enum()
+            )) )
+    {
+        const auto* repr = Target_GetTypeRepr(sp, resolve, ty);
+        return repr && repr->user_align;
+    }
+    return false;
 }
 const TypeRepr* Target_GetTypeRepr(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty)
 {

--- a/src/trans/target.hpp
+++ b/src/trans/target.hpp
@@ -83,6 +83,8 @@ struct TypeRepr
 {
     size_t  align = 0;
     size_t  size = 0;
+    /// gcc's `TYPE_USER_ALIGN`: `align` came from an explicit `repr(align(N))` somewhere inside, so it's exempt from a member-alignment cap
+    bool    user_align = false;
 
     struct FieldPath {
         size_t  index;
@@ -176,6 +178,11 @@ static inline unsigned Target_GetPointerBits() { return Target_GetCurSpec().m_ar
 extern bool Target_GetSizeOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_size);
 extern bool Target_GetAlignOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_align);
 extern bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty, size_t& out_size, size_t& out_align);
+
+/// Does this target's C ABI cap the alignment of a non-first struct member? (Darwin/PowerPC "power" alignment)
+extern bool Target_CapsMemberAlignment();
+/// gcc's `TYPE_USER_ALIGN`: such a type is exempt from the member-alignment cap above, wherever it appears.
+extern bool Target_TypeHasUserAlignment(const Span& sp, const StaticTraitResolve& resolve, const ::HIR::TypeRef& ty);
 
 /// This function is for the MIR Optimisation tool, which has to be able to read and use existing layouts
 extern void Target_ForceTypeRepr(const Span& sp, const ::HIR::TypeRef& ty, TypeRepr repr);

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -903,7 +903,8 @@ void Job_Build::push_args_common(StringList& args, const helpers::path& outfile,
     if( parent.m_opts.enable_debug ) {
         args.push_back("-g");
     }
-    if( true ) {
+    // `debug_assertions` enables `assert_unsafe_precondition!`, which a C-ABI-driven layout can't satisfy (8-aligned field at a 4-aligned offset)
+    if( !getenv("MINICARGO_NO_DEBUG_ASSERTIONS") ) {
         if( parent.is_rustc() ) {
             args.push_back("-C"); args.push_back("debug-assertions");
         }


### PR DESCRIPTION
Builds libcore and libstd for 32-bit PowerPC Mac OS X (10.4/10.5), and produces binaries that run there.

Most of the work is making mrustc's type layout agree with the C compiler's. mrustc emits every Rust type as a plain C struct and lets the C compiler lay it out, then writes `sizeof_assert`/`alignof_assert` typedefs alongside it - so any disagreement is a compile error in the generated C rather than silent corruption, and Darwin/PowerPC's "power" alignment ABI disagrees in four ways:

- A struct member that is not the first has its alignment capped to 4. This has to apply to Rust's own types, not just `repr(C)`. 32-bit PowerPC is the only arch here where it bites, being the only one with 32-bit pointers but 8-byte-aligned u64.
- The cap is on *natural* alignment only. gcc tracks this as TYPE_USER_ALIGN and applies the rule in `place_field` guarded by `if (! DECL_USER_ALIGN (field))`, so a `repr(align(N))` type keeps its alignment however deeply nested, and every aggregate containing it inherits the exemption. `TypeRepr::user_align` models that, propagating outward exactly as gcc does.
- A union takes its *first* member's alignment under this ABI, so codegen_c pins union alignment explicitly rather than letting the C compiler derive it. Members all sit at offset 0, so pinning moves nothing else.
- An align-1 type must be emitted packed even when it is not `repr(packed)`: gcc takes a container's alignment from the member's natural alignment, ignoring the `#pragma pack` the member was defined under, and `aligned(N)` cannot lower alignment to correct it.

A niche enum's size and alignment now come from the final variant layouts rather than from `max_align`, which predates the tag field and so sizes a non-leading payload as though it led. Guarded on the capping ABI; elsewhere the two agree by construction.

Also here:

- `*-apple-darwin` has an empty target_env, as in rustc. Declaring "gnu" made `#[cfg(target_env = "gnu")]` select glibc-specific code on a platform with no glibc. This fixes every apple-darwin target, not just this one.
- 32-bit PowerPC reports 8-byte atomics as available and links libatomic. They are lock-based there, but reporting them unavailable cfg's AtomicU64 out of libcore, which libstd's `sys::unix::time` uses unconditionally on macOS.
- Two libstd patches: `macos_weak` only defines the `fdopendir` weak symbol for x86/x86_64, and the Darwin thread parker needs libdispatch (10.6+), so this target falls through to the generic pthread parker.
- `MINICARGO_NO_DEBUG_ASSERTIONS`, because `debug_assertions` enables `assert_unsafe_precondition!`, which asserts Rust-level invariants a C-ABI-driven layout cannot satisfy - under the alignment cap an 8-aligned field sits at a 4-aligned offset and `ptr::write`'s precondition aborts during `rt::init`. The emitted C is correct; only the assertion disagrees.


This PR needs https://github.com/thepowersgang/mrustc/pull/417 to be merged before it will work.