### PR TITLE
minicargo: Preserve the semver pre-release suffix in CARGO_PKG_VERSION

### DIFF
--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -743,7 +743,8 @@ namespace {
     {
         env.push_back("CARGO_MANIFEST_DIR", manifest.directory().to_absolute());
         env.push_back("CARGO_PKG_NAME", manifest.name());
-        env.push_back("CARGO_PKG_VERSION", ::format(manifest.version()));
+        // Full form: build scripts derive identifiers from this
+        env.push_back("CARGO_PKG_VERSION", manifest.version().to_string_full());
         env.push_back("CARGO_PKG_VERSION_MAJOR", ::format(manifest.version().major));
         env.push_back("CARGO_PKG_VERSION_MINOR", ::format(manifest.version().minor));
         env.push_back("CARGO_PKG_VERSION_PATCH", ::format(manifest.version().patch));

--- a/tools/minicargo/manifest.cpp
+++ b/tools/minicargo/manifest.cpp
@@ -1560,7 +1560,15 @@ PackageVersion PackageVersion::from_string(const ::std::string& s)
         rv.patch = 0;
         rv.patch_set = false;
     }
-    if(iss.peek() == '+') {
+    // Semver is `-prerelease` then `+build`
+    if(iss.peek() == '-') {
+        iss.get();
+        ::std::getline(iss, rv.prerelease, '+');
+        if(!iss.eof()) {   // getline ate the '+'
+            iss >> rv.free_text;
+        }
+    }
+    else if(iss.peek() == '+') {
         iss.get();
         iss >> rv.free_text;
     }

--- a/tools/minicargo/manifest.h
+++ b/tools/minicargo/manifest.h
@@ -36,7 +36,8 @@ struct PackageVersion
     unsigned minor;
     unsigned patch;
     bool patch_set;
-    std::string free_text;
+    std::string free_text;  // Semver `+build`
+    std::string prerelease; // Semver `-prerelease`; not part of ordering
 
     explicit PackageVersion()
         : major(0), minor(0), patch(0), patch_set(false) {}
@@ -113,6 +114,18 @@ struct PackageVersion
             os << "+" << v.free_text;
         }
         return os;
+    }
+
+    /// Full version string, for CARGO_PKG_VERSION (`operator<<` feeds crate tags)
+    std::string to_string_full() const {
+        std::string rv = std::to_string(major) + "." + std::to_string(minor);
+        if(patch_set)
+            rv += "." + std::to_string(patch);
+        if(!prerelease.empty())
+            rv += "-" + prerelease;
+        if(!free_text.empty())
+            rv += "+" + free_text;
+        return rv;
     }
 };
 struct PackageVersionSpec


### PR DESCRIPTION
`PackageVersion::from_string` parsed the `+build` suffix but not `-prerelease`, so `3.0.0-alpha.2` silently became plain `3.0.0`. Build scripts that derive an identifier from CARGO_PKG_VERSION then generate the wrong name: protobuf's build.rs emits `VERSION_3_0_0` while its codegen'd .rs files reference `VERSION_3_0_0_ALPHA_2`, which fails to resolve.

The new `prerelease` field is deliberately not part of `cmp`/`operator==` -- pre-release ordering rules are subtle and changing resolution behaviour is a separate concern. It is exposed only through `to_string_full()`, used for CARGO_PKG_VERSION; `operator<<` is unchanged so crate tags and output filenames do not churn.