### PR TITLE
MIR Lower: don't register drop flags with the `match` pseudo-loop

### DIFF
--- a/samples/test/match_arm_cond_move_drop.rs
+++ b/samples/test/match_arm_cond_move_drop.rs
@@ -1,0 +1,37 @@
+// Regression test: a `while let` binding that one match arm conditionally
+// moves (via a method call) and another arm conditionally moves (via an
+// assignment to an outer local) must still be dropped on the arms that
+// don't move it. mrustc used to register the value's drop flag with the
+// `match` pseudo-loop instead of the enclosing real loop, so the flag was
+// only re-initialised on the path through one arm and the value leaked on
+// the others (seen as rustc_expand's MatcherPos leaking Rc<Vec<NamedMatch>>).
+use std::rc::Rc;
+
+struct MP { idx: usize, _m: Rc<u32> }
+
+fn run(p: &mut Vec<MP>, out: &mut Vec<MP>, kinds: &[u8], c: bool, d: bool) -> Option<usize> {
+    let mut e: Option<MP> = None;
+    while let Some(mp) = p.pop() {
+        match kinds[mp.idx] {
+            0 => { if c { out.push(mp); } }
+            1 => { if d { e = Some(mp); } }
+            _ => {}
+        }
+    }
+    e.map(|m| m.idx)
+}
+
+fn main() {
+    let kinds = [0u8, 1, 2, 0, 1];
+    for &(c, d) in &[(true, true), (false, false), (true, false), (false, true)] {
+        let shared = Rc::new(1u32);
+        let mut p = Vec::new();
+        let mut out = Vec::new();
+        for i in 0..kinds.len() {
+            p.push(MP { idx: i, _m: Rc::clone(&shared) });
+        }
+        let _ = run(&mut p, &mut out, &kinds, c, d);
+        // Only the values still held in `out` may keep the Rc alive.
+        assert_eq!(Rc::strong_count(&shared), 1 + out.len(), "leak with c={} d={}", c, d);
+    }
+}

--- a/src/mir/from_hir.hpp
+++ b/src/mir/from_hir.hpp
@@ -110,6 +110,8 @@ TAGGED_UNION(ScopeType, Owning,
         // TODO: Any drop flags allocated in the loop must be re-initialised at the start of the loop (or before a loopback)
         ::MIR::BasicBlockId   entry_bb;
         ::std::vector<unsigned> drop_flags;
+        /// Set for the pseudo-loop used by `match` lowering (never loops back, so drop flags are promoted past it).
+        bool is_match = false;
         }),
     (Freeze, struct {
         /// Has `unfreeze_scope` been called on this entry?
@@ -404,7 +406,7 @@ public:
     /// Scope for split code paths (e.g. `if`)
     ScopeHandle new_scope_split(const Span& sp);
     /// Scope for escapable code paths (e.g. `loop`)
-    ScopeHandle new_scope_loop(const Span& sp);
+    ScopeHandle new_scope_loop(const Span& sp, bool is_match=false);
     /// Prevent any mutation of states above this scope until `unfreeze_scope` is called
     ScopeHandle new_scope_freeze(const Span& sp);
 

--- a/src/mir/from_hir_match.cpp
+++ b/src/mir/from_hir_match.cpp
@@ -341,7 +341,7 @@ void MIR_LowerHIR_Match( MirBuilder& builder, MirConverter& conv, ::HIR::ExprNod
     auto next_block = builder.new_bb_unlinked();
 
     /// Top level scope for the match
-    auto match_scope = builder.new_scope_loop(node.span());
+    auto match_scope = builder.new_scope_loop(node.span(), /*is_match=*/true);
 
     // 1. Stop the current block so we can generate code before generating the pattern matching code
     auto first_cmp_block = builder.pause_cur_block();

--- a/src/mir/mir_builder.cpp
+++ b/src/mir/mir_builder.cpp
@@ -838,6 +838,9 @@ unsigned int MirBuilder::new_drop_flag(bool default_state)
     {
         if( auto* e = m_scopes.at(m_scope_stack[i]).data.opt_Loop() )
         {
+            // A `match` isn't actually a loop, so promote the drop flag to the parent scope.
+            if( e->is_match )
+                continue;
             e->drop_flags.push_back(rv);
             break;
         }
@@ -886,13 +889,14 @@ ScopeHandle MirBuilder::new_scope_split(const Span& sp)
     DEBUG("START (split) scope " << idx);
     return ScopeHandle { *this, idx };
 }
-ScopeHandle MirBuilder::new_scope_loop(const Span& sp)
+ScopeHandle MirBuilder::new_scope_loop(const Span& sp, bool is_match/*=false*/)
 {
     unsigned int idx = m_scopes.size();
     m_scopes.push_back( ScopeDef {sp, ScopeType::make_Loop({})} );
     m_scopes.back().data.as_Loop().entry_bb = m_current_block;
+    m_scopes.back().data.as_Loop().is_match = is_match;
     m_scope_stack.push_back( idx );
-    DEBUG("START (loop) scope " << idx);
+    DEBUG("START (loop" << (is_match ? ", match" : "") << ") scope " << idx);
     return ScopeHandle { *this, idx };
 }
 ScopeHandle MirBuilder::new_scope_freeze(const Span& sp)


### PR DESCRIPTION
Since 24b3e1d0 (`MIR Lower - Rework scopes for match`) every `match` — and
via HIR every `if` — is lowered inside a Loop scope. `new_drop_flag` attaches
a new flag to the innermost Loop scope so that `complete_scope` re-initialises
it at that scope's entry block.

For a match pseudo-loop that entry block is only reached by paths that enter
*this* match. So a flag created for a variable owned by an enclosing scope —
e.g. a `while let` binding that one arm conditionally moves — is never reset
on the other arms: it keeps the "moved" value from the previous iteration and
the value is never dropped.

Reproducer (`samples/test/match_arm_cond_move_drop.rs`, arm `_ => {}` leaks):

```rust
while let Some(mp) = p.pop() {
    match kinds[mp.idx] {
        0 => { if c { out.push(mp); } }
        1 => { if d { e = Some(mp); } }
        _ => {}
    }
}
```

`-Z dump-mir` shows `drop(_1 IF df$0)` at the end of the loop body while
`df$0 = 1` is only emitted in the entry block of one arm's pseudo-loop.

## Impact

This is what makes the mrustc-built rustc 1.90 exhaust the address space on
32-bit x86 while expanding `rustc_session`'s `options!`: `rustc_expand`'s
`parse_tt_inner` has exactly this shape, so every `MatcherPos` that fails to
match leaks its `Rc<Vec<NamedMatch>>` and every later `Rc::make_mut`
deep-clones. Memory grows cubically in the number of `options!` entries
(40 entries → 142 MB, 80 → 347 MB, 218 → OOM at 3 GB; LLVM-built rustc needs
108 MB). On x86_64 it is only masked by the larger address space.

## Fix

Mark the match pseudo-loop (`new_scope_loop(sp, is_match=true)`) and skip such
scopes when searching for the loop to register a drop flag with. The flag then
lands on the nearest real loop (reset every iteration) or on nothing at all
(function-entry default) — the behaviour before 24b3e1d0.

After the fix `rustc_session` compiles in ~300 MB RSS on i586.
