### PR TITLE
Codegen C: keep passing `-fno-tree-sra` on 32-bit x86

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1334,15 +1334,22 @@ namespace {
                     args.push_back("-O1");  // HACK: Work around mrustc #347 by reducing the optimisation level
                     break;
                 }
-#if defined(__GNUC__) && !defined(__clang__)
-#if __GNUC__ < 16 && !(__GNUC__ == 15 && __GNUC_MINOR__ > 1)
-                // HACK: Work around [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117423] by disabling an optimisation stage
-                if( opt.opt_level > 0 )
+                // HACK: Work around two GCC bugs by disabling an optimisation stage.
+                // - [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117423], fixed in GCC 15.2.
+                // - [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71460], still open, 32-bit x86
+                //   only - so there the flag cannot be dropped for any GCC version.
                 {
-                    args.push_back("-fno-tree-sra");
+                    bool need_no_tree_sra = (Target_GetCurSpec().m_arch.m_name == "x86");
+#if defined(__GNUC__) && !defined(__clang__)
+# if __GNUC__ < 16 && !(__GNUC__ == 15 && __GNUC_MINOR__ > 1)
+                    need_no_tree_sra = true;
+# endif
+#endif
+                    if( opt.opt_level > 0 && need_no_tree_sra )
+                    {
+                        args.push_back("-fno-tree-sra");
+                    }
                 }
-#endif
-#endif
                 if( opt.emit_debug_info )
                 {
                     args.push_back("-g");


### PR DESCRIPTION
32efba18 (`Codegen - Apply -fno-tree-sra flag conditionally for GCC 15.1 and
earlier`) drops the flag for GCC >= 15.2, assuming PR117423 was the only
reason for it. On 32-bit x86 there is a second, independent reason.

With SRA enabled, GCC routes a copy of the union of an enum such as

```rust
enum ParserNumber { F64(f64), U64(u64), I64(i64) }
```

through an x87 register, because one of the variants holds a `double`. x87
loads/stores quieten signalling NaNs, so a `u64` payload of the `U64` variant
whose bit pattern looks like an sNaN (`0x7ff4…`, `0xfff2…` — roughly 1 in 4096
hashes) silently gains bit 51 (+2^51).

This is the "scalarization of a union" variation of
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71460, open since 2016 and
present in every released GCC — reproduced on 12.3.1, 13.2.1, 14.3.1 and
15.3.1, at `-O1` through `-Os`.

## Impact

In the mrustc-built cargo this makes serde_json's `from_str::<u64>` return a
different number for such fingerprint hashes. cargo's `debug_assertions`
self-check in `write_fingerprint` (JSON round-trip + `hash_u64()` compare)
then panics with `assertion left == right failed`, and cargo afterwards hangs
in "waiting for other jobs to finish". Hit while bootstrapping rustc on i586,
non-deterministically — it depends on which crate hashes look like sNaNs.

Minimal reproducer under mrustc-built code:

```rust
serde_json::from_str::<u64>("9220060707025241381")  // 0x7ff4… -> 0x7ffc…
```

## Fix

Keep passing `-fno-tree-sra` when the target is 32-bit x86, whatever the
compiler version, and keep the existing version condition for the PR117423
reason on every other target.

Verified on i586 with GCC 15.3.1 by recompiling the generated C by hand
(`-C emit-build-command`): `-O1` is wrong, `-O1 -fno-tree-sra` is correct.
`-msse2 -mfpmath=sse` also fixes it but would make mrustc output require
SSE2, breaking plain i586 as a target.
