### PR TITLE
trans/target: Use uint128_t alignment for f128

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -809,7 +809,12 @@ bool Target_GetSizeAndAlignOf(const Span& sp, const StaticTraitResolve& resolve,
             return true;
         case ::HIR::CoreType::F128:
             out_size = 16;
-            out_align = g_target.m_arch.m_alignments.f64; //f128;
+            // The C backend emits `struct f128 { uint128_t v; }`, so its
+            // alignment must match `uint128_t` — same rule as for i128/u128.
+            if( g_target.m_backend_c.m_emulated_i128 )
+                out_align = g_target.m_arch.m_alignments.u64;
+            else
+                out_align = g_target.m_arch.m_alignments.u128;
             return true;
         case ::HIR::CoreType::Str:
             DEBUG("sizeof on a `str` - unsized");


### PR DESCRIPTION
`Target_GetSizeAndAlignOf` reports `f128` with `f64`'s alignment:

```cpp
case ::HIR::CoreType::F128:
    out_size = 16;
    out_align = g_target.m_arch.m_alignments.f64; //f128;
```

But the C backend emits `f128` as a wrapper around the 128-bit integer type:

```c
typedef struct f128 { uint128_t v; } f128;
```

so in the generated C its alignment is `uint128_t`'s — 16 wherever
`unsigned __int128` is naturally aligned (aarch64, x86_64), and the u64
emulation alignment otherwise. mrustc and the C compiler therefore disagree
about the layout of anything containing an `f128`.

## Impact

`(f128, i32)` is laid out by mrustc as `i32@0, f128@8` (size 24), while GCC
puts the wrapper at offset 16 (size 32). The emitted
`sizeof_assert_TUP_2_ZRTCp_ZRTCf` then fails and the generated C does not
compile. Hit on aarch64 while building rustc-1.90.0's libstd at the mrustc
bootstrap stage of an ALT Linux rust-1.95.0 package build.

## Fix

Mirror the existing i128/u128 rule: use the `u128` alignment, falling back to
`u64`'s when 128-bit integers are emulated. No change on targets where the two
already agree (e.g. i586, where `u64` and `u128` are both 4-byte aligned).

A proper `f128` entry in `TargetArch::Alignments` would be the cleaner fix —
the `//f128;` comment suggests that was the intent — but as long as the
backend spells `f128` as a `uint128_t` wrapper, the u128 alignment is the
value that keeps both sides in agreement.
