### PR TITLE
mir/from_hir: Stop relying on `m[k] = m.size()` evaluation order

### DIFF
--- a/src/mir/from_hir.cpp
+++ b/src/mir/from_hir.cpp
@@ -3191,8 +3191,9 @@ namespace {
             }
             ::std::map<unsigned,unsigned>   drop_flag_mapping;
             for(auto idx : ev.generator_drop_flags()) {
-                drop_flag_mapping[idx] = drop_flag_mapping.size();
-                DEBUG("df$" << idx << " = BIT" << drop_flag_mapping[idx]);
+                auto bit = static_cast<unsigned>(drop_flag_mapping.size());
+                drop_flag_mapping[idx] = bit;
+                DEBUG("df$" << idx << " = BIT" << bit);
             }
             // Add drop flags to the end
             auto drop_flags_field_idx = fields.size();


### PR DESCRIPTION
`drop_flag_mapping[idx] = drop_flag_mapping.size()` reads the map's size in the same statement that inserts into it, and C++14 leaves the order of the two operands unspecified: [expr.ass]/1 sequences the assignment after both, but says nothing about which comes first. P0145R3 pinned the right operand before the left one, and that landed in C++17 only, while mrustc builds with -std=c++14.

So GCC is free to evaluate the indexing first, and on i586 it does:

    std::map<unsigned, unsigned> m;
    for (unsigned idx : {10u, 20u, 30u})
        m[idx] = m.size();

With g++ 15.3.1 at every -O level that yields 1,2,3 on i586 and 0,1,2 on x86_64; -std=c++17 yields 0,1,2 on both. GCC is conforming here, so there is nothing to work around on its side.

The shifted values break the `i == flag_mapping.second` invariant in generator_make_drop and abort mrustc. That is what stopped the i586 bootstrap of rustc-1.90.0 at rustc_middle, the first crate with enough generators to reach the drop-glue path.

Link: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0145r3.pdf
Link: https://en.cppreference.com/w/cpp/language/eval_order