### PR TITLE
trans/target: Accept i686-unknown-linux-gnu as alias for the i586 target spec

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -431,7 +431,8 @@ namespace
         {
             return load_spec_from_file(target_name);
         }
-        else if(target_name == "i586-linux-gnu" || target_name == "i586-unknown-linux-gnu")
+        else if(target_name == "i586-linux-gnu" || target_name == "i586-unknown-linux-gnu"
+             || target_name == "i686-linux-gnu" || target_name == "i686-unknown-linux-gnu")
         {
             return TargetSpec {
                 "unix", "linux", "gnu", {CodegenMode::Gnu11, true, "i586-linux-gnu", BACKEND_C_OPTS_GNU},


### PR DESCRIPTION
This is necessary because ALT Linux's `%rust_host_triple` resolves to `i686-unknown-linux-gnu` on i586 builders (matching the upstream Rust naming, where `i686-` is the 32-bit hosting target), but mrustc only recognised `i586-unknown-linux-gnu` / `i586-linux-gnu`. With the spec now starting to pass `RUSTC_TARGET=%rust_host_triple` through to `minicargo.mk` so the bootstrap-rustc gets the right baked-in `CFG_COMPILER_HOST_TRIPLE`, an unmatched `i686-...` would otherwise fall through to `load_spec_from_file` and abort with a missing target spec.

i586 and i686 share the same `BACKEND_C_OPTS_GNU` / `ARCH_X86` target spec in mrustc (32-bit x86 Linux GNU, same alignment / pointer-bits / no SSE2 by default), so just list both triples in the same branch.