### PR TITLE
trans/codegen_c: Use a 128-bit-aware popcount for native u128/i128 ctpop

### DIFF
--- a/samples/test/i128.rs
+++ b/samples/test/i128.rs
@@ -6,6 +6,24 @@ fn u128_ops()
     assert_eq!( ((std::i128::MAX as u128) >> (128-8)) as u8, 0x7F );
 }
 
+// `__builtin_popcountll` is 64-bit, so a native-u128 target used to count
+// only the low half - which made `u128::BITS` (`Self::MAX.count_ones()`
+// in libcore) equal 64.
+#[inline(never)]
+fn count_ones_u128(v: u128) -> u32 { v.count_ones() }
+#[inline(never)]
+fn count_ones_i128(v: i128) -> u32 { v.count_ones() }
+
+#[test]
+fn count_ones()
+{
+    assert_eq!( count_ones_u128(0), 0 );
+    assert_eq!( count_ones_u128(std::u128::MAX), 128 );
+    assert_eq!( count_ones_u128(std::u128::MAX >> 64), 64 );
+    assert_eq!( count_ones_u128(1 << 127), 1 );
+    assert_eq!( count_ones_i128(-1), 128 );
+}
+
 #[test]
 fn print()
 {

--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -787,6 +787,11 @@ namespace {
                     << "static inline uint128_t intrinsic_cttz_u128(uint128_t v) {\n"
                     << "\treturn (v == 0 ? 128 : ((v&0xFFFFFFFFFFFFFFFF) == 0 ? __builtin_ctz64(v>>64) + 64 : __builtin_ctz64(v)));\n"
                     << "}\n"
+                    // `__builtin_popcountll` takes a 64-bit argument, so it
+                    // would silently drop the upper half of a `__int128`.
+                    << "static inline uint128_t intrinsic_popcount_u128(uint128_t v) {\n"
+                    << "\treturn (uint128_t)__builtin_popcountll((uint64_t)v) + (uint128_t)__builtin_popcountll((uint64_t)(v >> 64));\n"
+                    << "}\n"
                     ;
             }
 
@@ -7236,14 +7241,20 @@ namespace {
             }
             // - CounT POPulated
             else if( name == "ctpop" ) {
+                const auto& ty = params.m_types.at(0);
                 emit_lvalue(e.ret_val); m_of << " = ";
 
-                if( type_is_emulated_i128(params.m_types.at(0)) )
+                if( type_is_emulated_i128(ty) )
                 {
                     m_of << "popcount128("; emit_param(e.args.at(0)); m_of << ")";
                     if( TARGETVER_LEAST_1_90 ) {
                         m_of << ".lo";
                     }
+                }
+                else if( get_prim_size(ty) == 128 )
+                {
+                    // `__builtin_popcountll` would only count the low half.
+                    m_of << "intrinsic_popcount_u128("; emit_param(e.args.at(0)); m_of << ")";
                 }
                 else
                 {


### PR DESCRIPTION
This is necessary because mrustc's `ctpop` intrinsic emit on a target with native `__int128` (aarch64, x86_64, ...) was a bare `__builtin_popcountll(arg)`, and `__builtin_popcountll` takes a `uint64_t`, so the upper 64 bits of any wider value were silently truncated. `u128::MAX.count_ones()` therefore returned 64 instead of 128 in mrustc-built rustc, which made `u128::BITS` (defined in libcore as `Self::MAX.count_ones()` for the unsigned int macros) equal 64 on every native-u128 target.

The first place this caught fire was the stage-2 aarch64 build of `compiler-builtins`: every `hf64!("0x1....p+-N")` literal in libm's math routines (cbrt, asin, atan2, ...) const-evaluates `parse_finite` -> `u128_ilog2(sig) - sig_bits`, and `u128_ilog2` is `u128::BITS - 1 - v.leading_zeros()`. With BITS = 64, the subtraction `63_u32 - 75_u32` underflowed, const-eval reported `error[E0080]: attempt to compute 63_u32 - 75_u32, which would overflow`, rustc accumulated hundreds of identical errors and aborted via `FatalError::raise`.

Add an `intrinsic_popcount_u128` helper for the native case (modeled on the existing `intrinsic_ctlz_u128` / `intrinsic_cttz_u128`) that splits the value into two 64-bit halves before popcounting, and route u128/i128 ctpop through it. The emulated-i128 path keeps the existing `popcount128` helper (which already sums both halves) and the smaller-than-128-bit path is unchanged.

The `samples/test/i128.rs` case only discriminates on a target that takes the native path: the built-in `x86_64-unknown-linux-gnu` spec has `emulate-i128` on, so there it exercises `popcount128` instead. Verified both ways on x86_64 with a custom target spec that only flips `backend.c.emulate-i128` to false - the case fails with `left: 64, right: 128` before this change and passes after.