### PR TITLE
trans/target: Use natural align for the niche-tag entry, not its size

### DIFF
--- a/src/trans/target.cpp
+++ b/src/trans/target.cpp
@@ -2065,6 +2065,8 @@ namespace {
                             case 8: niche_ty = ::HIR::CoreType::U64;    break;
                             default:    BUG(sp, "Unknown niche size: " << niche_path);
                             }
+                            size_t niche_size, niche_align;
+                            Target_GetSizeAndAlignOf(sp, resolve, niche_ty, niche_size, niche_align);
                             // Generate raw struct reprs for all variants
                             // - Add `non_niche_offset` to all variants
                             assert(reprs.size() == variants.size());
@@ -2092,8 +2094,8 @@ namespace {
                                         // NOTE: Any target-specific field alignment adjustment happens in
                                         // make_type_repr_struct__inner - insert with the natural alignment here
                                         variants[i].ents.insert( variants[i].ents.begin(), Ent() );
-                                        variants[i].ents[0].align = niche_path.size;
-                                        variants[i].ents[0].size = niche_path.size;
+                                        variants[i].ents[0].size = niche_size;
+                                        variants[i].ents[0].align = niche_align;
                                         variants[i].ents[0].field = variants[i].ents.size() - 1;
                                         variants[i].ents[0].ty = niche_ty.clone();
                                         // Create the new repr
@@ -2109,12 +2111,12 @@ namespace {
                                         for(const auto& f : reprs[i]->fields) {
                                             max_ofs = std::max(max_ofs, f.offset + get_size_or_zero(sp, resolve, f.ty));
                                         }
-                                        // - Increase alignment to the niche size
-                                        if( max_ofs % niche_path.size != 0 ) {
-                                            max_ofs += niche_path.size - (max_ofs % niche_path.size);
+                                        // - Round up to the niche's alignment
+                                        if( max_ofs % niche_align != 0 ) {
+                                            max_ofs += niche_align - (max_ofs % niche_align);
                                         }
-                                        assert(niche_offset % niche_path.size == 0);
-                                        assert(max_ofs % niche_path.size == 0);
+                                        assert(niche_offset % niche_align == 0);
+                                        assert(max_ofs % niche_align == 0);
                                         ASSERT_BUG(sp, niche_offset >= max_ofs,
                                             "Niche offset (" << niche_offset << ") overlaps with variant data (" << max_ofs << ")");
                                         auto req_padding = niche_offset - max_ofs;
@@ -2126,8 +2128,8 @@ namespace {
                                             variants[i].ents.back().field = ~0u;
                                         }
                                         variants[i].ents.push_back(Ent());
-                                        variants[i].ents.back().align = niche_path.size;
-                                        variants[i].ents.back().size = niche_path.size;
+                                        variants[i].ents.back().size = niche_size;
+                                        variants[i].ents.back().align = niche_align;
                                         variants[i].ents.back().field = tag_fld_idx;
                                         variants[i].ents.back().ty = niche_ty.clone();
                                         // Create the new repr


### PR DESCRIPTION
This is necessary because the niche-optimisation branch of `make_type_repr_enum` was inserting the synthetic tag entry into every non-largest variant with both `size` and `align` set to `niche_path.size`, which over-constrains alignment on targets where the niche type's natural alignment is less than its size. On i586 (u64 has align=4) an 8-byte niche tag therefore made the new variant repr report align=8, breaking the `reprs[i]->align <= max_align` invariant the surrounding code relies on right after the recompute.

This was the next failure in the same function after the swapped size/align on the plain enum-tag entry was fixed, exposed once thorin-dwp could get past the `cur_ofs <= offset` assertion in the mrustc bootstrap stage of rustc-1.90.0 on i586. Query `Target_GetSizeAndAlignOf` for the chosen niche type and feed it to both the leading and trailing tag insertion paths.

Commit: c09c78dadeb24fff1e873e7b5b3cbb379dd7aaba