### PR TITLE
minicargo: Add --panic flag passing -C panic=<strategy> to mrustc

### DIFF
--- a/minicargo.mk
+++ b/minicargo.mk
@@ -105,6 +105,11 @@ else ifeq ($(RUSTC_VERSION),1.29.0)
 else
   VENDOR_DIR := $(RUSTCSRC)vendor
   MINICARGO_FLAGS += --manifest-overrides rustc-$(RUSTC_VERSION)-overrides.toml
+  # Pass `-C panic=unwind` to mrustc for these rustc versions so the panic-unwind
+  # runtime (which uses mrustc's setjmp/longjmp _Unwind_RaiseException shim) is
+  # selected instead of panic_abort. Without this, every emitted bin defaults
+  # to panic_abort and any rustc-driven FatalError aborts the process via libc.
+  MINICARGO_FLAGS += --panic unwind
 endif
 ifeq ($(RUSTC_VERSION),1.54.0)
   RUST_LIB_PREFIX := library/

--- a/tools/minicargo/build.cpp
+++ b/tools/minicargo/build.cpp
@@ -933,6 +933,9 @@ void Job_Build::push_args_common(StringList& args, const helpers::path& outfile,
     if( parent.m_opts.emit_mmir ) {
         args.push_back("-C"); args.push_back("codegen-type=monomir");
     }
+    if( parent.m_opts.panic_strategy && !parent.is_rustc() ) {
+        args.push_back("-C"); args.push_back(format("panic=", parent.m_opts.panic_strategy));
+    }
 
     for(const auto& d : parent.m_opts.lib_search_dirs)
     {

--- a/tools/minicargo/build.h
+++ b/tools/minicargo/build.h
@@ -22,6 +22,7 @@ struct BuildOptions
     bool emit_mmir = false;
     bool enable_debug = false;
     const char* target_name = nullptr;  // if null, host is used
+    const char* panic_strategy = nullptr;  // if non-null, passed to mrustc as -C panic=<strategy>
     enum class Mode {
         /// Build the binary/library
         Normal,

--- a/tools/minicargo/main.cpp
+++ b/tools/minicargo/main.cpp
@@ -63,6 +63,10 @@ struct ProgramOptions
     bool no_default_features = false;
     ::std::vector<::std::string>    features;
 
+    /// Panic strategy passed to mrustc as `-C panic=<strategy>` (e.g. "abort" or "unwind").
+    /// nullptr means "let mrustc pick its default" (currently `panic_abort`).
+    const char* panic_strategy = nullptr;
+
     int parse(int argc, const char* argv[]);
     void usage(::std::ostream& os) const;
     void help() const;
@@ -280,6 +284,7 @@ int main(int argc, const char* argv[])
         build_opts.emit_mmir = opts.emit_mmir;
         build_opts.enable_debug = opts.enable_debug;
         build_opts.target_name = opts.target;
+        build_opts.panic_strategy = opts.panic_strategy;
         for(const auto* d : opts.lib_search_dirs)
             build_opts.lib_search_dirs.push_back( ::helpers::path(d) );
         // Indicate desire to build tests (or examples) instead of the primary target
@@ -453,6 +458,13 @@ int ProgramOptions::parse(int argc, const char* argv[])
             else if( ::std::strcmp(arg, "--no-default-features") == 0 ) {
                 this->no_default_features = true;
             }
+            else if( ::std::strcmp(arg, "--panic") == 0 ) {
+                if(i+1 == argc) {
+                    ::std::cerr << "Flag " << arg << " takes an argument" << ::std::endl;
+                    return 1;
+                }
+                this->panic_strategy = argv[++i];
+            }
             else if( ::std::strcmp(arg, "--pause") == 0 ) {
                 this->pause_before_quit = true;
             }
@@ -499,5 +511,6 @@ void ProgramOptions::help() const
         << "-g                       : Pass `-g` to compiler\n"
         << "--no-default-features    : \n"
         << "--features <list>        : \n"
+        << "--panic <strategy>       : Pass `-C panic=<strategy>` to mrustc invocations (e.g. `unwind`)\n"
         ;
 }


### PR DESCRIPTION
mrustc falls back to loading panic_abort for any binary that needs a panic_runtime unless the user supplied -C panic=... on the mrustc command line: the `panic_runtime_needed` branch in `src/main.cpp` keys off `params.codegen.panic_type` being empty, and carries a `TODO: Get a panic method from the command line`. minicargo never plumbed that flag through, so every bin target (rustc itself, mrustc's own dump helper, tests) defaulted to panic_abort, regardless of what was sitting in libstd's dep graph. This is what made the previous panic_unwind override useless on rustc_main and what broke `lib/libproc_macro/tools/dump` once the panic_abort dep was deleted from libstd (libpanic_abort.rlib stopped being built, but mrustc still searched for it by name).

Add a CLI option to minicargo and a matching BuildOptions field; pass through to mrustc invocations only (real rustc speaks the flag too but we keep this conservative). minicargo.mk turns it on for the 1.39.0/1.54.0/1.74.0/1.90.0 chain steps where panic_unwind is the intended runtime; the older 1.19.0/1.29.0 paths stay on whatever default they already had.