### PR TITLE
trans/codegen_c: Honor "fastcall"/"stdcall"/"sysv64"/"win64" ABI on GCC

### DIFF
--- a/src/trans/codegen_c.cpp
+++ b/src/trans/codegen_c.cpp
@@ -1721,6 +1721,17 @@ namespace {
                 }
             }
         }
+        /// GCC calling-convention attribute for a Rust ABI string, NULL if the
+        /// ABI is the platform default (i.e. needs no attribute).
+        /// Link: https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html
+        static const char* gcc_abi_attribute(const RcString& abi)
+        {
+            if( abi == "fastcall" ) return "__attribute__((fastcall))";
+            if( abi == "stdcall"  ) return "__attribute__((stdcall))";
+            if( abi == "sysv64"   ) return "__attribute__((sysv_abi))";
+            if( abi == "win64"    ) return "__attribute__((ms_abi))";
+            return nullptr;
+        }
         void emit_type_fn(const ::HIR::TypeRef& ty)
         {
             if( m_emitted_fn_types.count(ty) ) {
@@ -1749,6 +1760,11 @@ namespace {
                 else
                 {
                 }
+            }
+            else if( m_compiler == Compiler::Gcc )
+            {
+                if( const char* attr = gcc_abi_attribute(te.m_abi) )
+                    m_of << attr << " ";
             }
             m_of << "*"; emit_ctype(ty); m_of << ")(";
             if( te.m_arg_types.size() == 0 )
@@ -5849,6 +5865,11 @@ namespace {
                 if( item.m_abi == "system" && m_compiler == Compiler::Msvc )
                 {
                     ss << " __stdcall";
+                }
+                else if( m_compiler == Compiler::Gcc )
+                {
+                    if( const char* attr = gcc_abi_attribute(item.m_abi) )
+                        ss << " " << attr;
                 }
                 ss << " " << Trans_Mangle(p) << "(";
                 if( item.m_args.size() == 0 )


### PR DESCRIPTION
This is necessary because mrustc previously ignored every non-default calling convention on GCC: emit_type_fn and emit_function_header only handled MSVC's "system" -> __stdcall. For any other ABI string the C output came out as plain cdecl on x86 (and the default SysV on x86_64), silently disagreeing with the declared Rust ABI.

On i586 this breaks `psm` (used by rustc via `stacker` for deep typecheck recursion). Its `extern_item!` macro picks the ABI per architecture, and under `target_arch = "x86"` that is `extern "fastcall"`, matching the hand-written assembly stubs in `vendor/psm/src/arch/x86.s` which read arguments from %ecx and %edx. With mrustc's cdecl emission those registers held whatever happened to be there at the call site, and `rust_psm_on_stack` then jumped through a garbage callback pointer onto an unrelated mmap page - producing the SIGSEGV during the i586 stage-2 libcore compile, with PC at a no-symbol address inside a high-mmap region and corrupt return frames in the backtrace.

The other architectures did not notice because the ABI the same macro picks for them is already what mrustc emits: plain C on aarch64, "sysv64" on x86_64 (the default C ABI on Linux) and "aapcs" on arm (likewise the default). "aapcs" is therefore left unhandled here rather than mapped to an attribute.

Link: https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html